### PR TITLE
fix: macOS 26 BNNS compiler compatibility for Sortformer

### DIFF
--- a/models/speaker-diarization/sortformer-streaming/conversion/convert_to_coreml.py
+++ b/models/speaker-diarization/sortformer-streaming/conversion/convert_to_coreml.py
@@ -76,8 +76,8 @@ def convert_head(
         ],
         outputs=[
             ct.TensorType(name="speaker_preds", dtype=np.float32),
-            ct.TensorType(name="chunk_pre_encoder_embs"),
-            ct.TensorType(name="chunk_pre_encoder_lengths")
+            ct.TensorType(name="chunk_pre_encoder_embs_out"),  # Renamed: macOS 26 requires distinct input/output names
+            ct.TensorType(name="chunk_pre_encoder_lengths_out")  # Renamed: macOS 26 requires distinct input/output names
         ],
         minimum_deployment_target=ct.target.iOS16,
         compute_precision=precision,
@@ -331,8 +331,8 @@ def export_pipeline(
 
             pipeline_model.output_description['speaker_preds'] = ("Combined speaker probabilities for the speaker "
                                                                   " cache, FIFO queue, and chunk")
-            pipeline_model.output_description['chunk_pre_encoder_embs'] = "Speaker embeddings for the new chunk"
-            pipeline_model.output_description['chunk_pre_encoder_lengths'] = "Number of frames for the new chunk"
+            pipeline_model.output_description['chunk_pre_encoder_embs_out'] = "Speaker embeddings for the new chunk"
+            pipeline_model.output_description['chunk_pre_encoder_lengths_out'] = "Number of frames for the new chunk"
             pipeline_model.save(os.path.join(output_dir, "SortformerPipeline.mlpackage"))
             print("  Saved SortformerPipeline.mlpackage (PreEncoder + Conformer + Transformer)")
         except Exception as e:

--- a/models/speaker-diarization/sortformer-streaming/conversion/coreml_wrappers.py
+++ b/models/speaker-diarization/sortformer-streaming/conversion/coreml_wrappers.py
@@ -106,7 +106,11 @@ class SortformerHeadWrapper(nn.Module):
         spkcache_fifo_chunk_preds = self.model.forward_infer(
             spkcache_fifo_chunk_fc_encoder_embs, spkcache_fifo_chunk_fc_encoder_lengths
         )
-        return spkcache_fifo_chunk_preds, chunk_pre_encoder_embs, chunk_pre_encoder_lengths
+        # Explicit identity ops to create distinct output tensors (required for macOS 26+)
+        # macOS 26 BNNS compiler rejects models where input and output tensors share the same name
+        chunk_pre_encoder_embs_out = chunk_pre_encoder_embs + 0.0  # identity via add
+        chunk_pre_encoder_lengths_out = chunk_pre_encoder_lengths + 0  # identity via add
+        return spkcache_fifo_chunk_preds, chunk_pre_encoder_embs_out, chunk_pre_encoder_lengths_out
 
 
 class SortformerCoreMLWrapper(nn.Module):


### PR DESCRIPTION
## Summary

- Fixes macOS 26 BNNS compiler error where input/output tensors cannot share the same name
- Adds explicit identity ops to create distinct output tensors
- Renames outputs to `*_out` suffix (`chunk_pre_encoder_embs_out`, `chunk_pre_encoder_lengths_out`)

## Problem

macOS 26 introduced stricter validation in the BNNS graph compiler:
```
Function main has tensor chunk_pre_encoder_embs as both an input and output.
Inputs and outputs must be distinct, please add an explicit identity op.
```

## Solution

1. **coreml_wrappers.py**: Add identity ops (`+ 0.0`) in `SortformerHeadWrapper` to create distinct output tensors
2. **convert_to_coreml.py**: Rename output tensor names to avoid collision

## Breaking Change

Models converted with this fix require FluidAudio to read from new output names:
- `chunk_pre_encoder_embs` → `chunk_pre_encoder_embs_out`
- `chunk_pre_encoder_lengths` → `chunk_pre_encoder_lengths_out`

V2 models uploaded to HuggingFace use these new names.

Fixes FluidInference/FluidAudio#265

 