### PR TITLE
fix: PocketTTS iOS 17 compatibility — remove scaled_dot_product_attention

### DIFF
--- a/models/tts/pocket_tts/coreml/CONVERSION.md
+++ b/models/tts/pocket_tts/coreml/CONVERSION.md
@@ -36,14 +36,14 @@ The pipeline is split into **4 CoreML models** plus numpy/sentencepiece for prep
 └──────────────────────┬──────────────────────────────────────┘
                        │
 ┌──────────────────────▼──────────────────────────────────────┐
-│  flow_decoder_v2.mlpackage   (flow decoding, 8 LSD steps)  │
+│  flow_decoder.mlpackage   (flow decoding, 8 LSD steps)  │
 │  Input:  transformer_out [1, 1024] + latent [1, 32] + s, t │
 │  Output: velocity [1, 32]                                   │
 │  Called: 8 times per generation step                         │
 └──────────────────────┬──────────────────────────────────────┘
                        │
 ┌──────────────────────▼──────────────────────────────────────┐
-│  mimi_decoder_v2.mlpackage   (audio synthesis)              │
+│  mimi_decoder.mlpackage   (audio synthesis)              │
 │  Input:  quantized latent [1, 512, 1] + streaming state     │
 │  Output: audio frame [1, 1, 1920] (80ms at 24kHz)           │
 │  Called: once per generation step                            │
@@ -114,9 +114,9 @@ The autoregressive backbone. Takes one latent frame, runs it through the transfo
 | EOS logit | `[1, 1, 1]` | EOS probability (threshold: -4.0) |
 | Updated caches/positions | | 12 tensors |
 
-### 3. Flow Decoder (`flow_decoder_v2.mlpackage`)
+### 3. Flow Decoder (`flow_decoder.mlpackage`)
 
-**Source:** `traceable_flow_decoder.py` → `convert_flow_decoder_v2.py`
+**Source:** `traceable_flow_decoder.py` → `convert_flow_decoder.py`
 
 Lagrangian Self-Distillation (LSD) flow decoder. Converts transformer output to a 32d audio latent via 8 iterative denoising steps.
 
@@ -143,7 +143,7 @@ Step 7: s=0.875, t=1.000
 
 **Output:** Velocity field `[1, 32]`. Applied as: `latent = latent + velocity * dt`
 
-### 4. Mimi Decoder (`mimi_decoder_v2.mlpackage`)
+### 4. Mimi Decoder (`mimi_decoder.mlpackage`)
 
 **Source:** Converted separately (streaming convolutional decoder).
 
@@ -209,7 +209,7 @@ Zero PyTorch dependency. Imports: `numpy`, `sentencepiece`, `safetensors`, `core
 
    b. Check EOS (logit > -4.0 → stop after frames_after_eos extra frames)
 
-   c. Flow decode (flow_decoder_v2 × 8 LSD steps):
+   c. Flow decode (flow_decoder × 8 LSD steps):
       latent = randn(1, 32) * sqrt(0.7)
       for i in 0..7:
         velocity = flow_decoder.predict(transformer_out, latent, s=i/8, t=(i+1)/8)
@@ -242,8 +242,8 @@ Reversing this order (text first) produces cosine similarity of only 0.6–0.9 i
 |-------|------|-------------|
 | flowlm_step | 289 MB | ~50 MB |
 | cond_step | 253 MB | ~45 MB |
-| flow_decoder_v2 | 37 MB | ~7 MB |
-| mimi_decoder_v2 | 20 MB | ~5 MB |
+| flow_decoder | 37 MB | ~7 MB |
+| mimi_decoder | 20 MB | ~5 MB |
 | Constants | 28 MB | ~28 MB |
 | **Total** | **627 MB** | **~135 MB** |
 
@@ -283,8 +283,8 @@ Requires PyTorch (one-time only):
 # 2. Convert models (each creates an .mlpackage)
 .venv/bin/python coreml/convert_models/convert/convert_cond_step.py
 .venv/bin/python coreml/convert_models/convert/convert_flowlm_step.py
-.venv/bin/python coreml/convert_models/convert/convert_flow_decoder_v2.py
-# mimi_decoder_v2 requires a custom functional wrapper (see convert_mimi_decoder.py)
+.venv/bin/python coreml/convert_models/convert/convert_flow_decoder.py
+# mimi_decoder requires a custom functional wrapper (see convert_mimi_decoder.py)
 
 # 3. Run generation (no PyTorch needed after conversion)
 .venv/bin/python coreml/generate_coreml_v4.py

--- a/models/tts/pocket_tts/coreml/convert_models/convert/convert_cond_step.py
+++ b/models/tts/pocket_tts/coreml/convert_models/convert/convert_cond_step.py
@@ -49,7 +49,7 @@ def convert():
     mlmodel = ct.convert(
         traced,
         inputs=inputs,
-        minimum_deployment_target=ct.target.macOS15,
+        minimum_deployment_target=ct.target.iOS17,
         compute_precision=ct.precision.FLOAT32,
     )
 

--- a/models/tts/pocket_tts/coreml/convert_models/convert/convert_flow_decoder_v2.py
+++ b/models/tts/pocket_tts/coreml/convert_models/convert/convert_flow_decoder_v2.py
@@ -44,11 +44,11 @@ def convert_flow_decoder():
             ct.TensorType(name="s", shape=(1, 1)),
             ct.TensorType(name="t", shape=(1, 1)),
         ],
-        minimum_deployment_target=ct.target.macOS15,
+        minimum_deployment_target=ct.target.iOS17,
         compute_precision=ct.precision.FLOAT32,
     )
 
-    output_path = "flow_decoder_v2.mlpackage"
+    output_path = "flow_decoder.mlpackage"
     print(f"Saving to {output_path}...")
     mlmodel.save(output_path)
 

--- a/models/tts/pocket_tts/coreml/convert_models/convert/convert_flowlm_step.py
+++ b/models/tts/pocket_tts/coreml/convert_models/convert/convert_flowlm_step.py
@@ -69,7 +69,7 @@ def convert_flowlm_step():
     mlmodel = ct.convert(
         traced,
         inputs=inputs,
-        minimum_deployment_target=ct.target.macOS15,
+        minimum_deployment_target=ct.target.iOS17,
         compute_precision=ct.precision.FLOAT32,
     )
 

--- a/models/tts/pocket_tts/coreml/convert_models/convert/convert_mimi_decoder.py
+++ b/models/tts/pocket_tts/coreml/convert_models/convert/convert_mimi_decoder.py
@@ -4,7 +4,7 @@ NOTE: The Mimi decoder uses in-place state mutations (state[:] = ...) in its
 streaming convolution layers (StreamingConv1d, StreamingConvTranspose1d).
 coremltools cannot convert these in-place operations directly.
 
-The existing mimi_decoder_v2.mlpackage was converted using a custom traceable
+The existing mimi_decoder.mlpackage was converted using a custom traceable
 wrapper that rewrites all streaming ops as functional (returning new tensors
 instead of mutating in place). This requires rewriting the forward pass of:
   - StreamingConv1d.forward()       (conv.py)
@@ -14,7 +14,7 @@ instead of mutating in place). This requires rewriting the forward pass of:
 The model has 26 streaming state tensors (see traceable_mimi_decoder.py for
 the full list) and produces 1920 audio samples per frame at 24kHz.
 
-To regenerate mimi_decoder_v2.mlpackage:
+To regenerate mimi_decoder.mlpackage:
 1. Create a functional TraceableMimiDecoder that avoids all in-place ops
 2. Trace with sequence_length=256 for attention caches
 3. Convert with compute_precision=FLOAT32, target=macOS15
@@ -68,7 +68,7 @@ def convert():
     print(
         "\nERROR: Direct conversion not supported due to in-place state mutations."
     )
-    print("The existing mimi_decoder_v2.mlpackage uses a custom functional wrapper.")
+    print("The existing mimi_decoder.mlpackage uses a custom functional wrapper.")
     print("See this file's docstring for details on how to regenerate it.")
     return None
 

--- a/models/tts/pocket_tts/coreml/convert_models/traceable/traceable_cond_step.py
+++ b/models/tts/pocket_tts/coreml/convert_models/traceable/traceable_cond_step.py
@@ -174,8 +174,12 @@ class TraceableCondStep(nn.Module):
         attn_mask = valid_mask & causal_mask
         attn_mask = attn_mask.unsqueeze(1)
 
-        # Attention
-        attn_output = F.scaled_dot_product_attention(q, keys, values, attn_mask=attn_mask, dropout_p=0.0)
+        # Manual attention (avoids scaled_dot_product_attention op for iOS 17 compat)
+        scale = 1.0 / (q.shape[-1] ** 0.5)
+        attn_weights = torch.matmul(q, keys.transpose(-2, -1)) * scale
+        attn_weights = attn_weights.masked_fill(~attn_mask, float("-inf"))
+        attn_weights = torch.softmax(attn_weights, dim=-1)
+        attn_output = torch.matmul(attn_weights, values)
 
         attn_output = attn_output.permute(0, 2, 1, 3).reshape(B, T, self.embed_dim)
         output = out_proj(attn_output)

--- a/models/tts/pocket_tts/coreml/convert_models/traceable/traceable_flowlm_step.py
+++ b/models/tts/pocket_tts/coreml/convert_models/traceable/traceable_flowlm_step.py
@@ -197,8 +197,12 @@ class TraceableFlowLMStep(nn.Module):
         attn_mask = valid_mask & causal_mask
         attn_mask = attn_mask.unsqueeze(1)
 
-        # Attention
-        attn_output = F.scaled_dot_product_attention(q, keys, values, attn_mask=attn_mask, dropout_p=0.0)
+        # Manual attention (avoids scaled_dot_product_attention op for iOS 17 compat)
+        scale = 1.0 / (q.shape[-1] ** 0.5)
+        attn_weights = torch.matmul(q, keys.transpose(-2, -1)) * scale
+        attn_weights = attn_weights.masked_fill(~attn_mask, float("-inf"))
+        attn_weights = torch.softmax(attn_weights, dim=-1)
+        attn_output = torch.matmul(attn_weights, values)
 
         attn_output = attn_output.permute(0, 2, 1, 3).reshape(B, T, self.embed_dim)
         output = out_proj(attn_output)

--- a/models/tts/pocket_tts/coreml/generate_coreml_v4.py
+++ b/models/tts/pocket_tts/coreml/generate_coreml_v4.py
@@ -33,7 +33,7 @@ COND_CACHE_KEYS = [
     "new_cache_internal_tensor_assign_2",
 ]
 COND_POS_KEYS = [
-    "var_430", "var_834", "var_1238", "var_1642", "var_2046", "var_2290",
+    "var_445", "var_864", "var_1283", "var_1702", "var_2121", "var_2365",
 ]
 
 # Generation step model output key names
@@ -46,7 +46,7 @@ STEP_CACHE_KEYS = [
     "new_cache_internal_tensor_assign_2",
 ]
 STEP_POS_KEYS = [
-    "var_443", "var_847", "var_1251", "var_1655", "var_2059", "var_2463",
+    "var_458", "var_877", "var_1296", "var_1715", "var_2134", "var_2553",
 ]
 
 
@@ -119,11 +119,11 @@ def generate_v4(text: str, voice: str = "alba", output_path: str = "coreml_v4.wa
         compute_units=ct.ComputeUnit.CPU_AND_GPU
     )
     coreml_flow = ct.models.MLModel(
-        os.path.join(SCRIPT_DIR, 'flow_decoder_v2.mlpackage'),
+        os.path.join(SCRIPT_DIR, 'flow_decoder.mlpackage'),
         compute_units=ct.ComputeUnit.CPU_AND_GPU
     )
     coreml_mimi = ct.models.MLModel(
-        os.path.join(SCRIPT_DIR, 'mimi_decoder_v2.mlpackage'),
+        os.path.join(SCRIPT_DIR, 'mimi_decoder.mlpackage'),
         compute_units=ct.ComputeUnit.CPU_AND_GPU
     )
 
@@ -192,7 +192,7 @@ def generate_v4(text: str, voice: str = "alba", output_path: str = "coreml_v4.wa
         step_out = coreml_step.predict(step_inputs)
 
         transformer_out = step_out['input']  # [1, 1, 1024]
-        eos_logit = step_out['var_2492']  # [1, 1, 1]
+        eos_logit = step_out['var_2582']  # [1, 1, 1]
 
         # Update caches/positions
         for i in range(6):


### PR DESCRIPTION
## Summary
- Replace `F.scaled_dot_product_attention` with manual matmul+softmax attention in traceable wrappers to fix BNNS crash on iOS
- Retarget all conversion scripts from macOS 15 / iOS 18 (spec 9) to iOS 17 (spec 8)
- Update `generate_coreml_v4.py` with new output tensor names from reconverted models
- Drop `_v2` suffix from model names (`flow_decoder`, `mimi_decoder`)

## Problem
Three PocketTTS CoreML models (`cond_step`, `flowlm_step`, `flow_decoder`) were converted targeting spec 9, which includes the fused `scaled_dot_product_attention` op. This op crashes Apple's BNNS library on iOS.

## Fix
- Decomposed SDPA into manual `Q×K^T / √d → mask → softmax → ×V` in `traceable_cond_step.py` (5 ops) and `traceable_flowlm_step.py` (6 ops)
- Changed `minimum_deployment_target` from `ct.target.macOS15` to `ct.target.iOS17` in all 3 convert scripts
- All reconverted models verified: spec 8, zero SDPA ops
- Full inference produces identical output (WER 0 on both short and long sentences)

## Test plan
- [x] Reconverted all 3 models (cond_step, flowlm_step, flow_decoder)
- [x] Verified zero SDPA ops in all 4 models
- [x] Python inference test passes (3.52s audio, EOS at step 41)
- [x] Swift TTS test: short sentence — WER 0, 5.52s audio
- [x] Swift TTS test: long sentence — WER 0, 5.76s audio
- [x] iOS build succeeds (`xcodebuild -destination 'generic/platform=iOS'`)
- [ ] Upload reconverted models to HuggingFace
- [ ] iOS device test by croqueteer