### PR TITLE
feat: bake denormalize + quantize into mimi_decoder

### DIFF
--- a/models/tts/pocket_tts/coreml/convert_models/convert/convert_mimi_decoder.py
+++ b/models/tts/pocket_tts/coreml/convert_models/convert/convert_mimi_decoder.py
@@ -1,72 +1,131 @@
-"""Verify Mimi streaming decoder CoreML model.
+"""Convert Mimi streaming decoder to CoreML.
 
-NOTE: The Mimi decoder uses in-place state mutations (state[:] = ...) in its
-streaming convolution layers (StreamingConv1d, StreamingConvTranspose1d).
-coremltools cannot convert these in-place operations directly.
+Traces the TraceableMimiDecoder (which bakes in denormalize + quantize)
+and converts to CoreML .mlpackage. Strips zero-length state tensors
+from the spec to avoid Espresso crash on iOS.
 
-The existing mimi_decoder.mlpackage was converted using a custom traceable
-wrapper that rewrites all streaming ops as functional (returning new tensors
-instead of mutating in place). This requires rewriting the forward pass of:
-  - StreamingConv1d.forward()       (conv.py)
-  - StreamingConvTranspose1d.forward()  (conv.py)
-  - MimiTransformerLayer attention cache updates  (mimi_transformer.py)
-
-The model has 26 streaming state tensors (see traceable_mimi_decoder.py for
-the full list) and produces 1920 audio samples per frame at 24kHz.
-
-To regenerate mimi_decoder.mlpackage:
-1. Create a functional TraceableMimiDecoder that avoids all in-place ops
-2. Trace with sequence_length=256 for attention caches
-3. Convert with compute_precision=FLOAT32, target=iOS17
-
-Input:  latent [1, 512, 1]  +  26 state tensors
-Output: audio  [1, 1, 1920] +  26 updated state tensors
-
-This script verifies the existing model instead of converting, since direct
-conversion is not possible without the functional wrapper.
+Input:  latent [1, 32]       +  23 state tensors (26 minus 3 zero-length)
+Output: audio  [1, 1, 1920]  +  23 updated state tensors
 """
+import torch
+import numpy as np
+import coremltools as ct
 import sys
 import os
-import numpy as np
 
 _SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 _CONVERT_MODELS_DIR = os.path.dirname(_SCRIPT_DIR)
 _COREML_DIR = os.path.dirname(_CONVERT_MODELS_DIR)
 _PROJECT_DIR = os.path.dirname(_COREML_DIR)
+sys.path.insert(0, _PROJECT_DIR)  # for: from pocket_tts import ...
+sys.path.insert(0, os.path.join(_CONVERT_MODELS_DIR, "traceable"))  # for: from traceable_* import ...
+
+from traceable_mimi_decoder import TraceableMimiDecoder, MIMI_STATE_SPEC
 
 
-def verify():
-    """Verify the existing mimi_decoder.mlpackage is iOS 17 compatible."""
-    import coremltools as ct
+def strip_zero_length_io(mlpackage_path):
+    """Remove zero-length tensor inputs/outputs from a saved CoreML mlpackage.
 
-    model_path = os.path.join(_COREML_DIR, "mimi_decoder.mlpackage")
+    Three Mimi state tensors have a zero-length dimension (kernel_size=1
+    streaming conv layers with 0 padding). CoreML Espresso crashes on
+    zero-element blobs, so we strip them from the spec.
 
-    if not os.path.exists(model_path):
-        print(f"ERROR: {model_path} not found.")
-        print("The mimi_decoder.mlpackage must be converted using a custom")
-        print("functional wrapper — see this file's docstring for details.")
-        return False
-
-    print(f"Loading {model_path}...")
-    mlmodel = ct.models.MLModel(model_path, compute_units=ct.ComputeUnit.CPU_AND_GPU)
+    Must operate on a saved .mlpackage (not in-memory) because mlProgram
+    models require the weights directory when loading from spec.
+    """
+    mlmodel = ct.models.MLModel(mlpackage_path, compute_units=ct.ComputeUnit.CPU_AND_GPU)
     spec = mlmodel.get_spec()
 
-    # Check spec version (7 = iOS 17 / macOS 14)
-    spec_version = spec.specificationVersion
-    print(f"\nSpec version: {spec_version}")
-    if spec_version <= 7:
-        print("  ✓ Compatible with iOS 17+ (spec version ≤ 7)")
-    else:
-        print(f"  ✗ Requires newer OS (spec version {spec_version})")
+    # Find zero-length input/output names
+    zero_inputs = set()
+    for inp in spec.description.input:
+        if inp.type.HasField('multiArrayType'):
+            shape = list(inp.type.multiArrayType.shape)
+            if 0 in shape:
+                zero_inputs.add(inp.name)
 
-    # Check for SDPA ops (would cause BNNS crash on iOS)
-    model_desc = str(spec)
-    has_sdpa = "scaled_dot_product_attention" in model_desc.lower()
-    print(f"\nScaled dot product attention (SDPA): {'FOUND ✗' if has_sdpa else 'None ✓'}")
-    if has_sdpa:
-        print("  WARNING: SDPA ops will cause BNNS crash on iOS.")
+    zero_outputs = set()
+    for out in spec.description.output:
+        if out.type.HasField('multiArrayType'):
+            shape = list(out.type.multiArrayType.shape)
+            if 0 in shape:
+                zero_outputs.add(out.name)
 
-    # Print input/output summary
+    if not zero_inputs and not zero_outputs:
+        print("No zero-length tensors to strip.")
+        return
+
+    print(f"Stripping {len(zero_inputs)} zero-length inputs: {zero_inputs}")
+    print(f"Stripping {len(zero_outputs)} zero-length outputs: {zero_outputs}")
+
+    # Remove from spec
+    inputs_to_keep = [inp for inp in spec.description.input
+                      if inp.name not in zero_inputs]
+    outputs_to_keep = [out for out in spec.description.output
+                       if out.name not in zero_outputs]
+
+    del spec.description.input[:]
+    spec.description.input.extend(inputs_to_keep)
+
+    del spec.description.output[:]
+    spec.description.output.extend(outputs_to_keep)
+
+    # Save modified spec back (with weights dir from the mlpackage)
+    weights_dir = os.path.join(mlpackage_path, "Data",
+                               "com.apple.CoreML", "weights")
+    updated = ct.models.MLModel(spec, weights_dir=weights_dir,
+                                compute_units=ct.ComputeUnit.CPU_AND_GPU)
+    updated.save(mlpackage_path)
+
+
+def convert():
+    print("Loading PocketTTS model...")
+    from pocket_tts import TTSModel
+    model = TTSModel.load_model(lsd_decode_steps=8)
+    model.eval()
+
+    print("Creating traceable Mimi decoder (with denormalize + quantize baked in)...")
+    traceable = TraceableMimiDecoder.from_tts_model(model)
+    traceable.eval()
+
+    # Build example inputs from MIMI_STATE_SPEC
+    print("Creating example inputs...")
+    latent = torch.randn(1, 32)
+    state_tensors = []
+    ct_inputs = [ct.TensorType(name="latent", shape=(1, 32))]
+
+    for name, shape in MIMI_STATE_SPEC:
+        t = torch.zeros(*shape)
+        state_tensors.append(t)
+        ct_inputs.append(ct.TensorType(name=name, shape=tuple(shape)))
+
+    example_inputs = (latent,) + tuple(state_tensors)
+
+    print(f"Tracing with {len(state_tensors)} state tensors...")
+    with torch.no_grad():
+        traced = torch.jit.trace(traceable, example_inputs)
+
+    print("Converting to CoreML...")
+    mlmodel = ct.convert(
+        traced,
+        inputs=ct_inputs,
+        minimum_deployment_target=ct.target.iOS17,
+        compute_precision=ct.precision.FLOAT32,
+    )
+
+    output_path = os.path.join(_COREML_DIR, "mimi_decoder.mlpackage")
+    print(f"Saving to {output_path}...")
+    mlmodel.save(output_path)
+
+    # NOTE: Zero-length I/O stripping is skipped for mlProgram format.
+    # The 3 zero-length state tensors (res{0,1,2}_conv1_prev) are kept in the
+    # model spec. The Swift side provides them as empty MLMultiArrays.
+    # Stripping from the spec description causes "Model and main function must
+    # have same number of inputs and states" because the MIL function still
+    # references them.
+
+    # Print I/O summary
+    spec = mlmodel.get_spec()
     print(f"\n=== INPUTS ({len(spec.description.input)}) ===")
     for inp in spec.description.input:
         if inp.type.HasField('multiArrayType'):
@@ -87,24 +146,18 @@ def verify():
             shape = list(inp.type.multiArrayType.shape)
             test_inputs[inp.name] = np.zeros(shape, dtype=np.float32)
 
-    try:
-        out = mlmodel.predict(test_inputs)
-        print(f"  ✓ Inference succeeded — {len(out)} outputs")
+    coreml_model = ct.models.MLModel(output_path, compute_units=ct.ComputeUnit.CPU_AND_GPU)
+    out = coreml_model.predict(test_inputs)
+    print(f"  Inference succeeded — {len(out)} outputs")
 
-        # Check audio output shape
-        for key, val in out.items():
-            if hasattr(val, 'shape') and len(val.shape) == 3 and val.shape[-1] == 1920:
-                print(f"  ✓ Audio output '{key}': {val.shape} (1920 samples = 80ms at 24kHz)")
-                break
-    except Exception as e:
-        print(f"  ✗ Inference failed: {e}")
-        return False
+    for key, val in out.items():
+        if hasattr(val, 'shape') and len(val.shape) == 3 and val.shape[-1] == 1920:
+            print(f"  Audio output '{key}': {val.shape} (1920 samples = 80ms at 24kHz)")
+            break
 
-    ios17_ok = spec_version <= 7 and not has_sdpa
-    print(f"\n{'✓ Model is iOS 17 compatible' if ios17_ok else '✗ Model needs reconversion for iOS 17'}")
-    return ios17_ok
+    print("\nDone!")
+    return output_path
 
 
 if __name__ == "__main__":
-    success = verify()
-    sys.exit(0 if success else 1)
+    convert()

--- a/models/tts/pocket_tts/coreml/convert_models/traceable/traceable_mimi_decoder.py
+++ b/models/tts/pocket_tts/coreml/convert_models/traceable/traceable_mimi_decoder.py
@@ -3,8 +3,18 @@
 Flattens the stateful Mimi decoder into explicit input/output tensors
 so it can be traced with torch.jit.trace and converted to CoreML.
 
-Input:  latent [1, 512, 1] + 26 state tensors
+Input:  latent [1, 32] + 26 state tensors
 Output: audio [1, 1, 1920] + 26 updated state tensors
+
+The model internally denormalizes and quantizes the 32-dim latent:
+  denorm = latent * emb_std + emb_mean        [1, 32]
+  quantized = Conv1d(denorm, 32→512)           [1, 512, 1]
+  audio = mimi_decode(quantized, state)        [1, 1, 1920]
+
+NOTE: The original Mimi model uses in-place tensor mutations (state[:] = ...)
+in StreamingConv1d, StreamingConvTranspose1d, and MimiStreamingMultiheadAttention.
+torch.jit.trace cannot handle in-place ops, so this module monkey-patches them
+with functional equivalents before tracing.
 """
 import torch
 import torch.nn as nn
@@ -41,63 +51,319 @@ MIMI_STATE_SPEC = [
     ("conv_final_first", [1]),
 ]
 
+# Mapping from MIMI_STATE_SPEC names to (module_path, key) in the nested state dict.
+# module_path comes from init_states(mimi.decoder), init_states(mimi.decoder_transformer),
+# and init_states(mimi.upsample).
+_SPEC_TO_NESTED = [
+    ("upsample_partial", "convtr", "partial"),
+    ("attn0_cache", "transformer.layers.0.self_attn", "cache"),
+    ("attn0_offset", "transformer.layers.0.self_attn", "offset"),
+    ("attn0_end_offset", "transformer.layers.0.self_attn", "end_offset"),
+    ("attn1_cache", "transformer.layers.1.self_attn", "cache"),
+    ("attn1_offset", "transformer.layers.1.self_attn", "offset"),
+    ("attn1_end_offset", "transformer.layers.1.self_attn", "end_offset"),
+    ("conv0_prev", "model.0", "previous"),
+    ("conv0_first", "model.0", "first"),
+    ("convtr0_partial", "model.2", "partial"),
+    ("res0_conv0_prev", "model.3.block.1", "previous"),
+    ("res0_conv0_first", "model.3.block.1", "first"),
+    ("res0_conv1_prev", "model.3.block.3", "previous"),
+    ("res0_conv1_first", "model.3.block.3", "first"),
+    ("convtr1_partial", "model.5", "partial"),
+    ("res1_conv0_prev", "model.6.block.1", "previous"),
+    ("res1_conv0_first", "model.6.block.1", "first"),
+    ("res1_conv1_prev", "model.6.block.3", "previous"),
+    ("res1_conv1_first", "model.6.block.3", "first"),
+    ("convtr2_partial", "model.8", "partial"),
+    ("res2_conv0_prev", "model.9.block.1", "previous"),
+    ("res2_conv0_first", "model.9.block.1", "first"),
+    ("res2_conv1_prev", "model.9.block.3", "previous"),
+    ("res2_conv1_first", "model.9.block.3", "first"),
+    ("conv_final_prev", "model.11", "previous"),
+    ("conv_final_first", "model.11", "first"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Functional (no in-place) forward replacements for tracing
+# ---------------------------------------------------------------------------
+
+def _functional_streaming_conv1d_forward(self, x, model_state):
+    """StreamingConv1d.forward without in-place tensor mutations."""
+    B, C, T = x.shape
+    S = self._stride
+    assert T > 0 and T % S == 0
+    if model_state is None:
+        state = self.init_state(B, 0)
+    else:
+        state = self.get_state(model_state)
+    TP = state["previous"].shape[-1]
+    previous = state["previous"]
+    first = state["first"]
+
+    if TP and self.pad_mode == "replicate":
+        assert T >= TP
+        init = x[..., :1]
+        previous = torch.where(first.view(-1, 1, 1), init, previous)
+
+    if TP:
+        x = torch.cat([previous, x], dim=-1)
+    y = self.conv(x)
+    if TP:
+        state["previous"] = x[..., -TP:]          # dict assign (not [:]=)
+        if self.pad_mode == "replicate":
+            state["first"] = torch.zeros_like(first)
+    return y
+
+
+def _functional_streaming_conv_transpose1d_forward(self, x, mimi_state):
+    """StreamingConvTranspose1d.forward without in-place tensor mutations."""
+    layer_state = self.get_state(mimi_state)
+    partial = layer_state["partial"]
+    y = self.convtr(x)
+    PT = partial.shape[-1]
+    if PT > 0:
+        # Overlap-add without in-place (no += or [:]=)
+        y = torch.cat([y[..., :PT] + partial, y[..., PT:]], dim=-1)
+        # Save new partial
+        new_partial = y[..., -PT:]
+        bias = self.convtr.bias
+        if bias is not None:
+            new_partial = new_partial - bias[:, None]
+        layer_state["partial"] = new_partial       # dict assign (not [:]=)
+        y = y[..., :-PT]
+    return y
+
+
+def _functional_complete(cache, end_offset, k, v):
+    """Attention KV cache update without in-place scatter or assignment."""
+    capacity = cache.shape[3]
+    B, H, T, D = k.shape
+    assert T > 0
+    indexes = torch.arange(T, device=end_offset.device, dtype=torch.long)
+    indexes = indexes + end_offset.long().view(-1, 1)
+    indexes = indexes % capacity
+
+    this_indexes = indexes.view(B, 1, T, 1).expand(-1, H, T, D).long()
+    # Non-inplace scatter (returns new tensor)
+    new_k = cache[0].scatter(2, this_indexes, k)
+    new_v = cache[1].scatter(2, this_indexes, v)
+
+    keys = new_k
+    values = new_v
+
+    indexes = torch.arange(capacity, device=end_offset.device, dtype=torch.long)
+    last_offset = end_offset.view(-1, 1) + T - 1
+    end_index = last_offset % capacity
+    delta = indexes - end_index
+    positions = torch.where(
+        delta <= 0, last_offset + delta, last_offset + delta - capacity
+    )
+    new_end_offset = end_offset + T
+    invalid = indexes >= new_end_offset.view(-1, 1)
+    positions = torch.where(invalid, torch.full_like(positions, -1), positions)
+
+    new_cache = torch.stack([new_k, new_v])
+    return keys, values, positions, new_cache, new_end_offset
+
+
+def _functional_complete_kv(self, k, v, model_state):
+    """MimiStreamingMultiheadAttention._complete_kv without in-place ops."""
+    from pocket_tts.modules.mimi_transformer import KVCacheResult
+    if model_state is None:
+        return KVCacheResult.from_kv(k, v)
+    layer_state = self.get_state(model_state)
+    keys, values, positions, new_cache, new_end_offset = _functional_complete(
+        layer_state["cache"], layer_state["end_offset"], k, v
+    )
+    layer_state["cache"] = new_cache
+    layer_state["end_offset"] = new_end_offset
+    return KVCacheResult(keys, values, positions)
+
+
+def _functional_attention_forward(self, query, model_state):
+    """MimiStreamingMultiheadAttention.forward with explicit float scale.
+
+    F.scaled_dot_product_attention computes 1/sqrt(d_k) from the tensor shape,
+    which produces an int32 reciprocal that CoreML cannot handle. This patch
+    passes scale as a pre-computed float constant.
+    """
+    import math
+    from einops import rearrange
+
+    B, T = query.shape[:2]
+
+    if model_state is None:
+        offset = torch.zeros(B, device=query.device, dtype=torch.long)
+    else:
+        offset = self.get_state(model_state)["offset"]
+
+    projected = self.in_proj(query)
+    q, k, v = rearrange(projected, "b t (p h d) -> p b h t d", p=3, h=self.num_heads)
+
+    q = q.permute(0, 2, 1, 3)
+    k = k.permute(0, 2, 1, 3)
+    q, k = self.rope(q, k, offset)
+    q = q.permute(0, 2, 1, 3)
+    k = k.permute(0, 2, 1, 3)
+
+    k, v, pos_k = self._complete_kv(k, v, model_state)
+    pos_k = pos_k[:, None]
+    pos_q = offset.view(-1, 1, 1) + torch.arange(T, device=q.device, dtype=torch.long).view(-1, 1)
+    delta = pos_q - pos_k
+    attn_bias = (pos_k >= 0) & (delta >= 0)
+    attn_bias = attn_bias & (delta < self.context)
+    attn_bias = attn_bias[:, None]
+
+    # Manual attention to avoid int32 reciprocal from F.scaled_dot_product_attention.
+    # The built-in computes 1/sqrt(D) where D=head_dim as an int tensor in the trace.
+    head_dim = q.shape[-1]
+    scale = 1.0 / math.sqrt(float(head_dim))
+    attn = torch.matmul(q, k.transpose(-2, -1)) * scale
+    attn = attn.masked_fill(~attn_bias, float('-inf'))
+    attn = torch.softmax(attn, dim=-1)
+    x = torch.matmul(attn, v)
+
+    x = rearrange(x, "b h t d -> b t (h d)")
+    x = self.out_proj(x)
+    return x
+
+
+def _patch_for_tracing(module):
+    """Monkey-patch all in-place ops in the module tree for torch.jit.trace."""
+    import types
+    from pocket_tts.modules.conv import StreamingConv1d, StreamingConvTranspose1d
+    from pocket_tts.modules.mimi_transformer import MimiStreamingMultiheadAttention
+
+    for name, child in module.named_modules():
+        if isinstance(child, StreamingConv1d):
+            child.forward = types.MethodType(
+                _functional_streaming_conv1d_forward, child
+            )
+        elif isinstance(child, StreamingConvTranspose1d):
+            child.forward = types.MethodType(
+                _functional_streaming_conv_transpose1d_forward, child
+            )
+        elif isinstance(child, MimiStreamingMultiheadAttention):
+            child._complete_kv = types.MethodType(
+                _functional_complete_kv, child
+            )
+            child.forward = types.MethodType(
+                _functional_attention_forward, child
+            )
+
+
+# ---------------------------------------------------------------------------
+# Main traceable wrapper
+# ---------------------------------------------------------------------------
 
 class TraceableMimiDecoder(nn.Module):
-    """Wrapper that exposes Mimi's streaming state as flat tensor I/O."""
+    """Wrapper that exposes Mimi's streaming state as flat tensor I/O.
 
-    def __init__(self, mimi_model):
+    Accepts a raw 32-dim latent and internally applies denormalization
+    (latent * emb_std + emb_mean) and quantization (Conv1d 32→512)
+    before feeding into the Mimi streaming decoder.
+
+    State tensors are ordered according to MIMI_STATE_SPEC (matching
+    the manifest.json order expected by the Swift loader).
+    """
+
+    def __init__(self, mimi_model, emb_mean, emb_std, quantize_proj):
         super().__init__()
         self.mimi = mimi_model
+        self.register_buffer("emb_mean", emb_mean)
+        self.register_buffer("emb_std", emb_std)
+        self.quantize_proj = quantize_proj
 
-        # Build the mapping from flat state list to nested model_state dict.
-        # init_states() returns {module_name: {key: tensor}}.
+        # Build the nested state dict from init_states.
         from pocket_tts.modules.stateful_module import init_states
-        self._nested_state = init_states(self.mimi.decoder, batch_size=1, sequence_length=1)
-        # Also add decoder_transformer and upsample states
+        self._nested_state = init_states(self.mimi.decoder, batch_size=1, sequence_length=256)
         self._nested_state.update(
-            init_states(self.mimi.decoder_transformer, batch_size=1, sequence_length=1)
+            init_states(self.mimi.decoder_transformer, batch_size=1, sequence_length=256)
         )
         if hasattr(self.mimi, 'upsample'):
             self._nested_state.update(
-                init_states(self.mimi.upsample, batch_size=1, sequence_length=1)
+                init_states(self.mimi.upsample, batch_size=1, sequence_length=256)
             )
+
+        # Validate the mapping covers all nested state entries
+        nested_keys = set()
+        for module_name, module_state in self._nested_state.items():
+            for key in module_state:
+                nested_keys.add((module_name, key))
+        spec_keys = set((m, k) for _, m, k in _SPEC_TO_NESTED)
+        assert nested_keys == spec_keys, (
+            f"Mapping mismatch:\n"
+            f"  In nested but not spec: {nested_keys - spec_keys}\n"
+            f"  In spec but not nested: {spec_keys - nested_keys}"
+        )
+
+        # Attention module paths in model_state for offset increment in forward().
+        # These match the module_name entries in _SPEC_TO_NESTED for offset keys.
+        self._attn_module_names = [
+            module_name
+            for spec_name, module_name, key in _SPEC_TO_NESTED
+            if key == "offset"
+        ]
+
+        # Upsample stride determines the offset increment per frame.
+        # Each latent frame [1, 512, 1] is upsampled to [1, 512, stride] tokens,
+        # so the decoder transformer attention processes `stride` tokens per call.
+        self._upsample_stride = int(self.mimi.upsample.convtr.convtr.stride[0])
+
+        # Patch in-place ops for tracing
+        _patch_for_tracing(self.mimi)
 
     @classmethod
     def from_tts_model(cls, tts_model) -> "TraceableMimiDecoder":
-        return cls(tts_model.mimi)
+        return cls(
+            tts_model.mimi,
+            emb_mean=tts_model.flow_lm.emb_mean,
+            emb_std=tts_model.flow_lm.emb_std,
+            quantize_proj=tts_model.mimi.quantizer.output_proj,
+        )
 
     def _pack_state(self, flat_tensors: tuple) -> dict:
-        """Convert flat tensor tuple into nested model_state dict."""
+        """Convert flat tensor tuple (MIMI_STATE_SPEC order) into nested dict."""
+        # Ensure all module_name keys exist in the dict
         state = {}
-        # Rebuild nested structure from init_states template
-        idx = 0
-        for module_name, module_state in self._nested_state.items():
+        for module_name in self._nested_state:
             state[module_name] = {}
-            for key in module_state:
-                state[module_name][key] = flat_tensors[idx]
-                idx += 1
+
+        for i, (spec_name, module_name, key) in enumerate(_SPEC_TO_NESTED):
+            state[module_name][key] = flat_tensors[i]
         return state
 
     def _unpack_state(self, state: dict) -> tuple:
-        """Extract flat tensor tuple from nested model_state dict."""
+        """Extract flat tensor tuple (MIMI_STATE_SPEC order) from nested dict."""
         tensors = []
-        for module_name, module_state in self._nested_state.items():
-            for key in module_state:
-                tensors.append(state[module_name][key])
+        for spec_name, module_name, key in _SPEC_TO_NESTED:
+            tensors.append(state[module_name][key])
         return tuple(tensors)
 
     def forward(self, latent, *state_tensors):
         """
         Args:
-            latent: [1, 512, 1] quantized latent frame
-            *state_tensors: 26 flat state tensors
+            latent: [1, 32] raw latent frame
+            *state_tensors: 26 flat state tensors (MIMI_STATE_SPEC order)
 
         Returns:
             audio: [1, 1, 1920] decoded audio frame
-            *updated_states: 26 updated state tensors
+            *updated_states: 26 updated state tensors (MIMI_STATE_SPEC order)
         """
+        # Denormalize: latent * std + mean
+        denorm = latent * self.emb_std + self.emb_mean  # [1, 32]
+        # Reshape to Conv1d input and quantize: [1, 32, 1] → [1, 512, 1]
+        quantized = self.quantize_proj(denorm.unsqueeze(-1))
         model_state = self._pack_state(state_tensors)
-        audio = self.mimi.decode_from_latent(latent, model_state)
+        audio = self.mimi.decode_from_latent(quantized, model_state)
+        # Functional increment_steps: advance attention offsets by upsample_stride.
+        # Each latent frame is upsampled to `stride` encoder tokens, so the
+        # decoder transformer attention processes `stride` tokens per frame.
+        # The original code calls increment_steps(mimi, state, increment=16).
+        for attn_name in self._attn_module_names:
+            layer_state = model_state[attn_name]
+            layer_state["offset"] = layer_state["offset"] + self._upsample_stride
         updated = self._unpack_state(model_state)
         return (audio,) + updated
 
@@ -110,7 +376,6 @@ def test_traceable_mimi():
     sys.path.insert(0, _project_dir)
 
     from pocket_tts import TTSModel
-    from pocket_tts.modules.stateful_module import init_states
 
     print("Loading model...")
     model = TTSModel.load_model(lsd_decode_steps=8)
@@ -120,23 +385,21 @@ def test_traceable_mimi():
     traceable = TraceableMimiDecoder.from_tts_model(model)
     traceable.eval()
 
-    # Build initial state
-    print("Building initial state...")
-    state = init_states(model.mimi.decoder, batch_size=1, sequence_length=1)
-    state.update(init_states(model.mimi.decoder_transformer, batch_size=1, sequence_length=1))
-    if hasattr(model.mimi, 'upsample'):
-        state.update(init_states(model.mimi.upsample, batch_size=1, sequence_length=1))
+    # Build initial state from MIMI_STATE_SPEC
+    print("Building initial state from MIMI_STATE_SPEC...")
+    state_tensors = []
+    for name, shape in MIMI_STATE_SPEC:
+        state_tensors.append(torch.zeros(*shape))
 
-    flat_state = traceable._unpack_state(state)
-    print(f"State tensors: {len(flat_state)}")
-    for i, t in enumerate(flat_state):
-        print(f"  [{i}] shape={list(t.shape)}")
+    print(f"State tensors: {len(state_tensors)}")
+    for i, (name, shape) in enumerate(MIMI_STATE_SPEC):
+        print(f"  [{i}] {name}: {shape}")
 
     # Test forward pass
     print("\nTesting forward pass...")
-    latent = torch.randn(1, 512, 1)
+    latent = torch.randn(1, 32)
     with torch.no_grad():
-        outputs = traceable(latent, *flat_state)
+        outputs = traceable(latent, *state_tensors)
 
     audio = outputs[0]
     print(f"Audio shape: {audio.shape}")

--- a/models/tts/pocket_tts/coreml/generate_coreml_v4.py
+++ b/models/tts/pocket_tts/coreml/generate_coreml_v4.py
@@ -103,9 +103,7 @@ def generate_v4(text: str, voice: str = "alba", output_path: str = "coreml_v4.wa
 
     # 5. Load constants
     bos_emb = np.load(os.path.join(CONST_DIR, "bos_emb.npy"))
-    emb_mean = np.load(os.path.join(CONST_DIR, "emb_mean.npy"))
-    emb_std = np.load(os.path.join(CONST_DIR, "emb_std.npy"))
-    q_weight = np.load(os.path.join(CONST_DIR, "quantizer_weight.npy"))  # [512, 32, 1]
+    # emb_mean, emb_std, quantizer_weight are now baked into mimi_decoder
     mimi_state_npz = dict(np.load(os.path.join(CONST_DIR, "mimi_init_state.npz")))
 
     # 6. Load CoreML models
@@ -223,14 +221,8 @@ def generate_v4(text: str, voice: str = "alba", output_path: str = "coreml_v4.wa
             velocity = list(flow_out.values())[0]
             latent = latent + velocity * dt
 
-        # Denormalize + quantize
-        latent_denorm = latent * emb_std.reshape(1, -1) + emb_mean.reshape(1, -1)
-        # q_weight is [512, 32, 1] (1D conv kernel), squeeze to [512, 32]
-        w = q_weight.squeeze(-1)  # [512, 32]
-        quantized = np.dot(latent_denorm, w.T).reshape(1, 512, 1)
-
-        # Mimi decode
-        mimi_inputs = {'latent': quantized.astype(np.float32), **coreml_mimi_state}
+        # Mimi decode (denormalize + quantize baked into model)
+        mimi_inputs = {'latent': latent.astype(np.float32), **coreml_mimi_state}
         mimi_out = coreml_mimi.predict(mimi_inputs)
 
         audio_frame = mimi_out['var_1445']


### PR DESCRIPTION
## Summary
- Rework `TraceableMimiDecoder` to accept raw `[1, 32]` latent instead of pre-processed `[1, 512, 1]`, baking denormalize + quantize into the CoreML model
- Add functional (no in-place) replacements for `StreamingConv1d`, `StreamingConvTranspose1d`, and `MimiStreamingMultiheadAttention` to enable `torch.jit.trace`
- Replace `F.scaled_dot_product_attention` with manual matmul to avoid int32 reciprocal CoreML conversion error
- Add attention offset increment (stride=16) matching original `increment_steps(mimi, state, increment=16)`
- Rewrite `convert_mimi_decoder.py` from verify stub to full conversion script

## Test plan
- [ ] Run `python convert_mimi_decoder.py` to produce `mimi_decoder.mlpackage`
- [ ] Compile with `xcrun coremlcompiler compile mimi_decoder.mlpackage`
- [ ] Run TTS inference in Swift and verify audio quality
- [ ] Verify attention offsets increment by 16 per frame (not 1)