### PR TITLE
Add ASR verification requirement for TTS model conversions

### DIFF
--- a/Documentation/ModelConversion.md
+++ b/Documentation/ModelConversion.md
@@ -185,6 +185,40 @@ uv run python test.py audio/sample.wav
 
 If the conversion has a comparison script, the PyTorch-vs-CoreML latency numbers from Step 4 already cover this.
 
+### TTS models: ASR verification required
+
+**For TTS (Text-to-Speech) conversions only**: You must verify the converted model using automatic speech recognition (ASR) to ensure semantic accuracy. Traditional verification methods (spectral similarity, mel-spectrogram comparison) can pass even when generated audio contains incorrect words, missing phonemes, or garbled speech that "looks" spectrally similar but is unintelligible.
+
+**Requirements:**
+1. Generate audio samples using both PyTorch (reference) and CoreML (converted) models
+2. Transcribe all generated audio using an ASR model (Whisper, FluidAudio Parakeet, or equivalent)
+3. Calculate Word Error Rate (WER) for both outputs compared to input text
+4. Verify WER < 10% and PyTorch vs CoreML transcription difference < 2%
+5. Document results with sample transcriptions in README
+
+**Example verification:**
+```python
+import whisper
+from jiwer import wer
+
+test_texts = ["Your test sentences here...", "At least 20-30 diverse samples..."]
+asr_model = whisper.load_model("base")
+
+for text in test_texts:
+    # Generate audio with PyTorch and CoreML
+    pt_audio = generate_pytorch(text)
+    cm_audio = generate_coreml(text)
+
+    # Transcribe and compare
+    pt_transcription = asr_model.transcribe(pt_audio)["text"]
+    cm_transcription = asr_model.transcribe(cm_audio)["text"]
+
+    print(f"PyTorch WER: {wer(text, pt_transcription):.2%}")
+    print(f"CoreML WER:  {wer(text, cm_transcription):.2%}")
+```
+
+Use diverse test samples covering different lengths, phonetic variety, and edge cases (numbers, punctuation, proper nouns). Report aggregate WER in your README.
+
 ---
 
 ## Step 6: Explore quantization (optional)


### PR DESCRIPTION
## Summary

Adds ASR verification requirement for TTS model conversions to the existing ModelConversion.md guide.

## Changes

- **Documentation/ModelConversion.md**: Added "TTS models: ASR verification required" section to Step 5 with requirements and example code

## Why This Matters

Traditional TTS verification methods (spectral similarity, mel-spectrogram comparison) can pass even when generated audio contains:
- Incorrect word pronunciation
- Missing or added words  
- Garbled speech that looks spectrally similar but is unintelligible

ASR verification catches these semantic errors by transcribing the generated audio and comparing it to the input text.

## Requirements for TTS Conversions

All TTS model conversions must now:
1. Generate audio with both PyTorch (reference) and CoreML (converted) models
2. Transcribe outputs using Whisper or FluidAudio ASR models  
3. Calculate Word Error Rate (WER) for both outputs
4. Verify WER < 10% and PyTorch vs CoreML difference < 2%
5. Use diverse test samples (20-30 covering different lengths, phonetics, edge cases)
6. Document results with sample transcriptions in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)