### PR TITLE
Add standalone CTC head export for parakeet-tdt-ctc-110m

### DIFF
--- a/models/stt/parakeet-tdt-ctc-110m/coreml/export-ctc-head.py
+++ b/models/stt/parakeet-tdt-ctc-110m/coreml/export-ctc-head.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Export standalone CTC decoder head from hybrid TDT-CTC model to CoreML.
+
+The CTC head is a single linear projection (encoder_dim -> vocab_size + 1)
+that maps encoder features to CTC log-probabilities. This tiny model (~0.5MB)
+enables custom vocabulary support without a separate CTC encoder.
+
+Architecture:
+    TDT Preprocessor -> encoder [1, D, T]
+                              |
+                        CtcHead model -> ctc_logits [1, T, V+1]
+                              |
+                  keyword spotting / vocabulary rescoring
+
+Usage:
+    uv run python export-ctc-head.py --output-dir ./ctc-head-build
+    uv run python export-ctc-head.py --nemo-path ./model.nemo --output-dir ./ctc-head-build
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional, Tuple
+
+import coremltools as ct
+import numpy as np
+import torch
+import typer
+
+import nemo.collections.asr as nemo_asr
+
+from individual_components import CTCDecoderWrapper
+
+DEFAULT_MODEL_ID = "nvidia/parakeet-tdt_ctc-110m"
+AUTHOR = "Fluid Inference"
+
+app = typer.Typer(add_completion=False, pretty_exceptions_show_locals=False)
+
+
+def _tensor_shape(tensor: torch.Tensor) -> Tuple[int, ...]:
+    return tuple(int(dim) for dim in tensor.shape)
+
+
+@app.command()
+def export(
+    nemo_path: Optional[Path] = typer.Option(
+        None,
+        "--nemo-path",
+        exists=True,
+        resolve_path=True,
+        help="Path to hybrid TDT-CTC .nemo checkpoint",
+    ),
+    model_id: str = typer.Option(
+        DEFAULT_MODEL_ID,
+        "--model-id",
+        help="Model identifier when --nemo-path is omitted",
+    ),
+    output_dir: Path = typer.Option(
+        Path("ctc-head-build"),
+        help="Output directory for CtcHead.mlpackage",
+    ),
+    max_audio_seconds: float = typer.Option(
+        15.0, "--max-audio-seconds", help="Fixed waveform window (seconds)"
+    ),
+    compute_units: str = typer.Option(
+        "CPU_AND_NE",
+        "--compute-units",
+        help="Compute units: ALL, CPU_ONLY, CPU_AND_NE",
+    ),
+) -> None:
+    """Export CTC decoder head as standalone CoreML model."""
+
+    cu_mapping = {
+        "ALL": ct.ComputeUnit.ALL,
+        "CPU_ONLY": ct.ComputeUnit.CPU_ONLY,
+        "CPU_AND_GPU": ct.ComputeUnit.CPU_AND_GPU,
+        "CPU_AND_NE": ct.ComputeUnit.CPU_AND_NE,
+    }
+    cu = cu_mapping.get(compute_units.upper())
+    if cu is None:
+        raise typer.BadParameter(f"Unknown compute units: {compute_units}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Load hybrid model
+    typer.echo(f"Loading hybrid TDT-CTC model ({'file' if nemo_path else 'pretrained'})...")
+    if nemo_path is not None:
+        asr_model = nemo_asr.models.EncDecHybridRNNTCTCBPEModel.restore_from(
+            str(nemo_path), map_location="cpu"
+        )
+    else:
+        asr_model = nemo_asr.models.EncDecHybridRNNTCTCBPEModel.from_pretrained(
+            model_id, map_location="cpu"
+        )
+    asr_model.eval()
+
+    # Probe dimensions
+    sample_rate = int(asr_model.cfg.preprocessor.sample_rate)
+    max_samples = int(round(max_audio_seconds * sample_rate))
+    vocab_size = int(asr_model.tokenizer.vocab_size)
+
+    # Get encoder hidden size by running a reference forward pass
+    typer.echo("Running reference forward pass to determine shapes...")
+    dummy_audio = torch.randn(1, max_samples, dtype=torch.float32)
+    dummy_length = torch.tensor([max_samples], dtype=torch.int32)
+
+    with torch.inference_mode():
+        mel, mel_length = asr_model.preprocessor(
+            input_signal=dummy_audio, length=dummy_length.long()
+        )
+        encoded, encoded_length = asr_model.encoder(
+            audio_signal=mel, length=mel_length.long()
+        )
+
+    encoder_dim = int(encoded.shape[1])  # [B, D, T]
+    time_steps = int(encoded.shape[2])
+    typer.echo(f"  encoder output: [{encoded.shape[0]}, {encoder_dim}, {time_steps}]")
+    typer.echo(f"  vocab_size: {vocab_size}, ctc_classes: {vocab_size + 1}")
+
+    # Wrap CTC decoder head
+    ctc_decoder = CTCDecoderWrapper(asr_model.ctc_decoder.eval())
+
+    # Reference CTC output
+    with torch.inference_mode():
+        ctc_ref = ctc_decoder(encoded)
+    typer.echo(f"  ctc_ref output: {_tensor_shape(ctc_ref)}")
+
+    # Trace
+    typer.echo("Tracing CTC decoder head...")
+    dummy_encoder_output = torch.randn(1, encoder_dim, time_steps, dtype=torch.float32)
+    traced = torch.jit.trace(ctc_decoder, (dummy_encoder_output,), strict=False)
+    traced.eval()
+
+    # Verify trace output
+    with torch.inference_mode():
+        trace_out = traced(dummy_encoder_output)
+    typer.echo(f"  traced output: {_tensor_shape(trace_out)}")
+    max_diff = (ctc_ref - trace_out).abs().max().item()
+    typer.echo(f"  max diff (ref vs traced): {max_diff:.6e}")
+
+    # Convert to CoreML
+    typer.echo("Converting to CoreML...")
+    mlmodel = ct.convert(
+        traced,
+        convert_to="mlprogram",
+        inputs=[
+            ct.TensorType(
+                name="encoder_output",
+                shape=(1, encoder_dim, time_steps),
+                dtype=np.float32,
+            ),
+        ],
+        outputs=[
+            ct.TensorType(name="ctc_logits", dtype=np.float32),
+        ],
+        compute_units=cu,
+        minimum_deployment_target=ct.target.iOS17,
+    )
+
+    # Save
+    mlpackage_path = output_dir / "CtcHead.mlpackage"
+    mlmodel.short_description = (
+        f"CTC decoder head for parakeet-tdt-ctc-110m "
+        f"(encoder_dim={encoder_dim}, vocab={vocab_size}+1 blank)"
+    )
+    mlmodel.author = AUTHOR
+    mlmodel.save(str(mlpackage_path))
+    typer.echo(f"Saved: {mlpackage_path}")
+
+    # Save metadata
+    metadata = {
+        "model": "parakeet-tdt-ctc-110m-ctc-head",
+        "source": model_id if nemo_path is None else str(nemo_path),
+        "encoder_dim": encoder_dim,
+        "time_steps": time_steps,
+        "vocab_size": vocab_size,
+        "ctc_classes": vocab_size + 1,
+        "blank_id": vocab_size,
+        "max_audio_seconds": max_audio_seconds,
+        "input": {"encoder_output": [1, encoder_dim, time_steps]},
+        "output": {"ctc_logits": list(_tensor_shape(ctc_ref))},
+    }
+    meta_path = output_dir / "ctc_head_metadata.json"
+    meta_path.write_text(json.dumps(metadata, indent=2))
+    typer.echo(f"Saved metadata: {meta_path}")
+
+    typer.echo(f"\nDone! To compile and install:")
+    typer.echo(f"  xcrun coremlcompiler compile {mlpackage_path} {output_dir}/")
+    typer.echo(f"  cp -R {output_dir}/CtcHead.mlmodelc ~/Library/Application\\ Support/FluidAudio/Models/parakeet-tdt-ctc-110m/")
+
+
+if __name__ == "__main__":
+    app()

--- a/models/stt/parakeet-tdt-ctc-110m/coreml/individual_components.py
+++ b/models/stt/parakeet-tdt-ctc-110m/coreml/individual_components.py
@@ -105,6 +105,17 @@ class JointWrapper(torch.nn.Module):
         return out
 
 
+class CTCDecoderWrapper(torch.nn.Module):
+    """CTC decoder head: encoder -> log-probabilities."""
+
+    def __init__(self, module: torch.nn.Module) -> None:
+        super().__init__()
+        self.module = module
+
+    def forward(self, encoder_output: torch.Tensor) -> torch.Tensor:
+        return self.module(encoder_output=encoder_output)
+
+
 class MelEncoderWrapper(torch.nn.Module):
     """Fused waveform -> mel -> encoder."""
 
@@ -121,6 +132,33 @@ class MelEncoderWrapper(torch.nn.Module):
         mel, mel_length = self.preprocessor(audio_signal, audio_length)
         encoded, enc_len = self.encoder(mel, mel_length.to(dtype=torch.int32))
         return encoded, enc_len
+
+
+class MelEncoderCtcWrapper(torch.nn.Module):
+    """Fused waveform -> mel -> encoder + CTC logits.
+
+    Outputs both TDT encoder features and CTC logits for unified custom vocabulary.
+    This eliminates the need for a separate CTC encoder model.
+    """
+
+    def __init__(
+        self,
+        preprocessor: PreprocessorWrapper,
+        encoder: EncoderWrapper,
+        ctc_decoder: torch.nn.Module,
+    ) -> None:
+        super().__init__()
+        self.preprocessor = preprocessor
+        self.encoder = encoder
+        self.ctc_decoder = ctc_decoder
+
+    def forward(
+        self, audio_signal: torch.Tensor, audio_length: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        mel, mel_length = self.preprocessor(audio_signal, audio_length)
+        encoded, enc_len = self.encoder(mel, mel_length.to(dtype=torch.int32))
+        ctc_logits = self.ctc_decoder(encoder_output=encoded)
+        return encoded, enc_len, ctc_logits
 
 
 class JointDecisionWrapper(torch.nn.Module):


### PR DESCRIPTION
## Summary
- Add `export-ctc-head.py` to export the CTC decoder head (512→1025 linear projection) as a standalone CoreML model (~1MB)
- Add `CTCDecoderWrapper` to `individual_components.py` for tracing the CTC head
- Eliminates the need for the full 97.5MB CTC encoder for custom vocabulary keyword spotting

## Context
Ref: FluidInference/FluidAudio#435

The hybrid parakeet-tdt-ctc-110m model shares one encoder between TDT and CTC heads. By exporting just the CTC decoder head as a tiny 1MB CoreML model, we can run it on the existing TDT encoder output to get CTC logits for keyword spotting — achieving 99.4% Dict Recall at 70.29x RTFx on the earnings benchmark.

## Usage
```bash
cd models/stt/parakeet-tdt-ctc-110m/coreml/
uv run python export-ctc-head.py --output-dir ./ctc-head-build
xcrun coremlcompiler compile ctc-head-build/CtcHead.mlpackage ctc-head-build/
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/mobius/pull/36" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
