### PR TITLE
feat(tts/styletts2): CoreML conversion (4-stage, int8 TP, 4.32× RTFx)

### DIFF
--- a/models/tts/styletts2/.gitignore
+++ b/models/tts/styletts2/.gitignore
@@ -1,0 +1,13 @@
+# Generated artifacts — do not commit. License posture: local-only.
+coreml/*.mlpackage/
+coreml/*.mlmodelc/
+checkpoints/
+reference_audio/
+
+# Upstream code is vendored locally for tracing; do not redistribute via this repo.
+vendor/
+
+__pycache__/
+.uv/
+.venv/
+*.pyc

--- a/models/tts/styletts2/.gitignore
+++ b/models/tts/styletts2/.gitignore
@@ -11,3 +11,6 @@ __pycache__/
 .uv/
 .venv/
 *.pyc
+
+# HF upload staging — symlinks into coreml/, do not commit.
+hf-upload/

--- a/models/tts/styletts2/LICENSE_REVIEW.md
+++ b/models/tts/styletts2/LICENSE_REVIEW.md
@@ -1,0 +1,41 @@
+# StyleTTS2 — License Review
+
+Before redistributing any converted artifacts, resolve the items below.
+
+## Code
+
+- **Upstream repo**: [yl4579/StyleTTS2](https://github.com/yl4579/StyleTTS2) — **MIT**.
+  Code-only changes (conversion scripts, traceable wrappers) are unencumbered.
+
+## Pre-trained weights
+
+- **`yl4579/StyleTTS2-LibriTTS`** and **`yl4579/StyleTTS2-LJSpeech`** ship with
+  custom restrictions in the upstream README beyond MIT. Specifically:
+  - Synthesized speech must disclose synthetic origin
+  - Speaker-consent restrictions on voice cloning use
+
+This is **not** a permissive ML-model license. Any redistribution (HuggingFace
+upload, app bundle, public download URL) needs explicit confirmation that
+these terms are preserved and surfaced to end users.
+
+## Training data
+
+- **LibriTTS** is CC-BY-4.0. The trained weights are a derivative work; the
+  weight license is the author's call (see above).
+- **LJSpeech** is public domain.
+
+## Action items before any distribution
+
+- [ ] Confirm the exact upstream weight license text (current README at the
+      time of conversion).
+- [ ] Confirm with counsel that converted CoreML packages can be redistributed
+      under the same terms, with end-user disclosure.
+- [ ] If the answer is "no", pivot to a permissively-licensed StyleTTS2
+      derivative (e.g. Kokoro-class weights, Apache-2.0) before any public
+      release.
+
+## Default posture (this branch)
+
+Converted `.mlpackage` files stay **on local disk**. Not committed to the repo,
+not uploaded to HuggingFace, not bundled into FluidAudio's downloadable model
+set. `coreml/*.mlpackage` is gitignored.

--- a/models/tts/styletts2/PLAN.md
+++ b/models/tts/styletts2/PLAN.md
@@ -1,0 +1,104 @@
+# StyleTTS2 → CoreML Conversion Plan
+
+## 1. Inference flow we are reproducing
+
+Source: `Demo/Inference_LibriTTS.ipynb` in [yl4579/StyleTTS2](https://github.com/yl4579/StyleTTS2).
+
+```
+text
+  └─ phonemizer (espeak-ng en-us, with_stress) ─┐
+                                                ▼
+                                        TextCleaner → tokens (1, T_tok)
+                                                │
+        ┌───────────────────────────────────────┼──────────────────────────────┐
+        ▼                                       ▼                              ▼
+  TextEncoder(tokens)                   PL-BERT(tokens)                 StyleEncoder(ref_mel)
+   → t_en (1,512,T_tok)                  → bert_dur (1,T_tok,768)         → ref_s (1,256)
+                                        bert_encoder(bert_dur)
+                                          → d_en (1,512,T_tok)
+
+  s_pred = ADPM2_sample(noise=(1,1,256),
+                        embedding=bert_dur,
+                        features=ref_s,
+                        steps=5, cfg_scale=1.0)
+  s_pred = α·s_pred + (1-α)·ref_s
+  ref, s = s_pred.split([128,128])      # ref → decoder; s → predictor
+
+  d = predictor.text_encoder(d_en, s, lengths)
+  x, _ = predictor.lstm(d)
+  pred_dur = sigmoid(predictor.duration_proj(x)).sum(-1).round().clamp(min=1)
+
+  pred_aln_trg = one_hot_alignment(pred_dur)             # (T_tok, T_mel)
+  en  = d.transpose(-1,-2) @ pred_aln_trg                # (1,512,T_mel)
+  asr = t_en              @ pred_aln_trg                 # (1,512,T_mel)
+
+  F0, N = predictor.F0Ntrain(en, s)                      # (1,T_mel) each
+  wav   = decoder(asr, F0, N, ref)                       # (1, T_mel*300)  @ 24 kHz
+```
+
+## 2. Split into CoreML packages
+
+| # | Package                      | Compute units | Why                                                     |
+|---|------------------------------|---------------|---------------------------------------------------------|
+| A | `styletts2_text_predictor`   | CPU + GPU     | BiLSTM (TextEncoder + DurationEncoder) — ANE rejects    |
+| B | `styletts2_diffusion_step`   | CPU + GPU     | Single UNet step. Sampler loop runs in Swift            |
+| C | `styletts2_f0n_energy`       | ANE           | AdainResBlk1d stack — pure conv, fixed shapes           |
+| D | `styletts2_decoder`          | ANE           | HiFi-GAN (Conv1d + ConvTranspose1d + snake activation)  |
+
+### Bucketing
+
+| Axis  | Buckets                       | Notes                                 |
+|-------|-------------------------------|---------------------------------------|
+| T_tok | 32, 64, 128, 256, 512         | Pad with PAD; covers ~most utterances |
+| T_mel | 256, 512, 1024, 2048, 4096    | ≈3.2 / 6.4 / 12.8 / 25.6 / 51.2 s     |
+
+Use `coremltools.EnumeratedShapes` per Kokoro precedent.
+
+## 3. Swift-side responsibilities
+
+- Phonemization (espeak-ng) — reuse FluidAudio's existing G2P path
+- TextCleaner → 178-token mapping (table exported as JSON)
+- ADPM2 + Karras sigma schedule + CFG batching, calling Package B 5×
+- `pred_aln_trg` build (cumsum + scatter) and matmul with `t_en` / `d`
+- Style blending `α·s_pred + (1-α)·ref_s`
+- Reference style extraction from a WAV (small CoreML or Accelerate path TBD)
+
+## 4. Conversion blockers + mitigations
+
+| Blocker                                                         | Mitigation                                                            |
+|-----------------------------------------------------------------|-----------------------------------------------------------------------|
+| Diffusion sampler `for` loop + `**kwargs` plumbing (issue #245) | Convert single denoise step; loop in Swift                            |
+| Variable `T_tok` / `T_mel`                                      | EnumeratedShapes buckets                                              |
+| `torch.stft` / complex tensors in iSTFTNet                      | Use HiFi-GAN variant (LibriTTS); LJSpeech deferred                    |
+| BiLSTM dynamic seq                                              | Pin Package A to CPU+GPU                                              |
+| Hard-alignment Python loop                                      | Build matrix in Swift                                                 |
+| Discriminators / optimizer state in `.pth` (~600 MB unused)     | Strip in `00_fetch_weights.py`; keep inference modules only           |
+
+## 5. Script order
+
+```
+scripts/00_fetch_weights.py          # download .pth, strip to inference modules
+scripts/01_export_text_predictor.py  # → coreml/styletts2_text_predictor.mlpackage
+scripts/02_export_diffusion_step.py  # → coreml/styletts2_diffusion_step.mlpackage
+scripts/03_export_f0n_energy.py      # → coreml/styletts2_f0n_energy.mlpackage
+scripts/04_export_decoder.py         # → coreml/styletts2_decoder.mlpackage
+scripts/99_parity_check.py           # PyTorch ↔ CoreML cosine on intermediate tensors
+```
+
+Each export script: load PyTorch module → wrap with a thin traceable adapter
+(no kwargs, fixed dtypes) → `torch.jit.trace` → `coremltools.convert` with
+`EnumeratedShapes`.
+
+## 6. Open questions
+
+- [ ] Inference-only param count after stripping the `.pth` (estimated 100–180 M; needs measurement).
+- [ ] Whether the HiFi-GAN ConvTranspose1d strides (10/5/3/2) place on ANE; needs empirical test.
+- [ ] Whether to ship `StyleEncoder` as its own `.mlpackage` for runtime ref-clip extraction, or pre-compute styles offline.
+- [ ] Whether to stay on yl4579 weights (license risk) or pivot to a permissively-licensed StyleTTS2 derivative for any future redistribution.
+
+## 7. Out of scope (this branch)
+
+- LJSpeech / iSTFTNet variant
+- Multilingual PL-BERT (papercup-ai/multilingual-pl-bert)
+- HuggingFace upload of converted artifacts
+- VoiceInk app integration

--- a/models/tts/styletts2/README.md
+++ b/models/tts/styletts2/README.md
@@ -1,0 +1,109 @@
+# StyleTTS2 — CoreML Conversion
+
+[yl4579/StyleTTS2](https://github.com/yl4579/StyleTTS2) (LibriTTS multi-speaker
+checkpoint) ported to CoreML for on-device inference on Apple Silicon
+(macOS 14+ / iOS 17+).
+
+**Status:** all four stages converted, optimized, and validated end-to-end.
+Vendored upstream is in `vendor/StyleTTS2/` (gitignored). Shared loader and
+traceable wrappers in `scripts/_styletts2_lib.py`. See `coreml/PRECISION.md`
+for the precision/quantization recipe and `coreml/TRIALS.md` for the
+chronological conversion log.
+
+## Headline numbers
+
+- **RTFx:** 4.32× warm (M-series Mac, 5-step ADPM2 sampler)
+- **On-disk size:** 871 MB (down from 1062 MB unoptimized)
+- **Log-mel cosine vs PyTorch fp32:** 0.9687
+- **Voice-clone fidelity (ECAPA-TDNN cos to ref):** 0.18 — at the model's
+  architectural ceiling (PyTorch fp32 itself is 0.29; see TRIALS.md Phase 5)
+
+## Run
+
+```bash
+cd models/tts/styletts2
+uv sync
+uv run python scripts/00_fetch_weights.py
+uv run python scripts/01_export_text_predictor.py
+uv run python scripts/02_export_diffusion_step.py
+uv run python scripts/03_export_f0n_energy.py
+uv run python scripts/04_export_decoder.py
+uv run python scripts/optimize/quantize_text_predictor_int8.py
+uv run python scripts/99c_e2e_optimized.py
+```
+
+Each export script accepts `--trace-only` to validate the PyTorch trace
+without invoking `coremltools.convert` (useful for fast iteration).
+
+## Target
+
+- Initial checkpoint: **LibriTTS multi-speaker** (`yl4579/StyleTTS2-LibriTTS`,
+  `Models/LibriTTS/epochs_2nd_00020.pth`). HiFi-GAN decoder — avoids
+  `torch.stft` / complex tensors. Multi-speaker via reference clip → `ref_s`.
+- Follow-up (not in initial scope): LJSpeech (iSTFTNet decoder; would need a
+  Swift-side iSTFT).
+
+## CoreML model split
+
+| Package                                  | CU        | Precision        | Buckets                        | Inputs                                                   | Called      |
+|------------------------------------------|-----------|------------------|--------------------------------|----------------------------------------------------------|-------------|
+| `styletts2_text_predictor_{B}.mlpackage` | ANE       | **int8** (selective) | `B ∈ {32, 64, 128, 256, 512}` | `tokens (1, T_tok)`                                      | 1× per utt  |
+| `styletts2_diffusion_step_512.mlpackage` | CPU+GPU   | fp16             | 1 (512)                        | `x`, `sigma`, `embedding (bert_dur)`, `features (ref_s)` | ~5× per utt |
+| `styletts2_f0n_energy.mlpackage`         | ANE       | fp16             | dynamic                        | `en (1, 512, T_mel)`, `s (1, 128)`                       | 1× per utt  |
+| `styletts2_decoder_{M}.mlpackage`        | CPU+GPU   | fp16             | `M ∈ {256, 512, 1024, 2048, 4096}` | `asr`, `F0`, `N`, `ref (1, 128)`                  | 1× per utt  |
+
+The diffusion sampler loop (ADPM2 + Karras schedule + CFG) lives in Swift and
+calls `styletts2_diffusion_step_512.mlpackage` `num_steps` (default 5) times
+per utterance. The hard-alignment matrix (cumsum of predicted durations →
+one-hot → matmul) also lives in Swift.
+
+**Why only one diffusion bucket?** Empirically every `bert_dur` we observed
+fit in the 512 bucket and the cost ladder is non-linear (B=32: 66 ms/step,
+B=512: 152 ms/step), so the 4 smaller buckets were dead weight (192 MB).
+See TRIALS.md Phase 4.
+
+**Why text_predictor int8 but not the others?** It's the only stage with
+≥200 k-element weight tensors that runs at scale across the bucket family.
+Quantizing the iterative diffusion step or the conv-heavy decoder either
+compounds error or produces audible periodic artifacts (TRIALS.md Phase 3).
+
+## Phonemizer
+
+espeak-ng IPA + stress (same family as Kokoro / PocketTTS). The 178-token
+vocabulary in `text_utils.TextCleaner` differs from Kokoro and is exported as
+JSON in `coreml/constants/`.
+
+## Layout
+
+```
+models/tts/styletts2/
+├── README.md              # this file
+├── PLAN.md                # original design + risks + open questions
+├── LICENSE_REVIEW.md      # upstream weight licensing concerns
+├── pyproject.toml         # conversion env (uv-managed)
+├── .gitignore             # excludes vendor/, checkpoints/, coreml/*.mlpackage/
+├── coreml/
+│   ├── PRECISION.md       # mixed-precision recipe + per-stage rationale
+│   ├── TRIALS.md          # chronological conversion log
+│   └── *.mlpackage        # generated artifacts (gitignored)
+├── vendor/StyleTTS2/      # upstream repo, cloned locally, gitignored
+└── scripts/
+    ├── _styletts2_lib.py             # shared loader + traceable wrappers
+    ├── 00_fetch_weights.py           # download .pth, strip discriminators
+    ├── 01_export_text_predictor.py   # → text+predictor mlpackage  (ANE)
+    ├── 02_export_diffusion_step.py   # → diffusion-step mlpackage  (CPU+GPU)
+    ├── 03_export_f0n_energy.py       # → F0/N mlpackage            (ANE)
+    ├── 04_export_decoder.py          # → HiFi-GAN decoder mlpackage (CPU+GPU)
+    ├── 99_parity_check.py            # PyTorch ↔ CoreML cosine check (per stage)
+    ├── 99b_e2e_coreml.py             # baseline e2e driver (no quantization)
+    ├── 99c_e2e_optimized.py          # optimized e2e: int8 TP + diff B=512 + warmup
+    └── optimize/
+        ├── quantize_text_predictor_int8.py  # fp16 → int8 PTQ for all 5 TP buckets
+        └── measure_diffusion_buckets.py     # per-bucket warm timing
+```
+
+## License
+
+The yl4579 LibriTTS weights ship with non-permissive consent / disclosure
+terms in the upstream README. Treat any converted artifacts as **local-only**.
+See `LICENSE_REVIEW.md` before any redistribution.

--- a/models/tts/styletts2/README.md
+++ b/models/tts/styletts2/README.md
@@ -29,7 +29,10 @@ uv run python scripts/02_export_diffusion_step.py
 uv run python scripts/03_export_f0n_energy.py
 uv run python scripts/04_export_decoder.py
 uv run python scripts/optimize/quantize_text_predictor_int8.py
-uv run python scripts/99c_e2e_optimized.py
+# `99c_e2e_optimized.py` needs a reference WAV (any 24 kHz speech clip; the
+# style encoder is robust to ~5 s of speech). Output goes to
+# /tmp/styletts2-e2e/coreml_int8_diff512.wav by default.
+uv run python scripts/99c_e2e_optimized.py --reference-wav <path/to/ref.wav>
 ```
 
 Each export script accepts `--trace-only` to validate the PyTorch trace

--- a/models/tts/styletts2/README.md
+++ b/models/tts/styletts2/README.md
@@ -29,7 +29,6 @@ uv run python scripts/01_export_text_predictor.py
 uv run python scripts/02_export_diffusion_step.py
 uv run python scripts/03_export_f0n_energy.py
 uv run python scripts/04_export_decoder.py
-uv run python scripts/optimize/quantize_text_predictor_int8.py
 # `99c_e2e_optimized.py` needs a reference WAV (any 24 kHz speech clip; the
 # style encoder is robust to ~5 s of speech). Output goes to
 # /tmp/styletts2-e2e/coreml_int8_diff512.wav by default.
@@ -51,7 +50,7 @@ without invoking `coremltools.convert` (useful for fast iteration).
 
 | Package                                  | CU        | Precision        | Buckets                        | Inputs                                                   | Called      |
 |------------------------------------------|-----------|------------------|--------------------------------|----------------------------------------------------------|-------------|
-| `styletts2_text_predictor_{B}.mlpackage` | ANE       | **int8** (selective) | `B ∈ {32, 64, 128, 256, 512}` | `tokens (1, T_tok)`                                      | 1× per utt  |
+| `styletts2_text_predictor_{B}.mlpackage` | ANE       | fp16             | `B ∈ {32, 64, 128, 256, 512}` | `tokens (1, T_tok)`                                      | 1× per utt  |
 | `styletts2_diffusion_step_512.mlpackage` | CPU+GPU   | fp16             | 1 (512)                        | `x`, `sigma`, `embedding (bert_dur)`, `features (ref_s)` | ~5× per utt |
 | `styletts2_f0n_energy.mlpackage`         | ANE       | fp16             | dynamic                        | `en (1, 512, T_mel)`, `s (1, 128)`                       | 1× per utt  |
 | `styletts2_decoder_{M}.mlpackage`        | CPU+GPU   | **fp32**         | `M ∈ {256, 512, 1024, 2048, 4096}` | `asr`, `F0`, `N`, `ref (1, 128)`                  | 1× per utt  |
@@ -66,10 +65,13 @@ fit in the 512 bucket and the cost ladder is non-linear (B=32: 66 ms/step,
 B=512: 152 ms/step), so the 4 smaller buckets were dead weight (192 MB).
 See TRIALS.md Phase 4.
 
-**Why text_predictor int8 but not the others?** It's the only stage with
-≥200 k-element weight tensors that runs at scale across the bucket family.
-Quantizing the iterative diffusion step or the conv-heavy decoder either
-compounds error or produces audible periodic artifacts (TRIALS.md Phase 3).
+**Why fp16 across text_predictor / diffusion / f0n and fp32 only on the
+decoder?** Selective int8 PTQ on text_predictor was tried and dropped
+(see `coreml/PRECISION.md` — ANE has no int8 GEMM, so the only payoff
+is ~3 MB of bandwidth per bucket; not worth the per-bucket validation
+cost). The decoder must be fp32 because SineGen accumulates phase to
+~4000 magnitude and fp16 collapses the sine output to a few discrete
+values (see `coreml/PHASE6_FP16_DECODER.md`).
 
 ## Phonemizer
 
@@ -100,9 +102,9 @@ models/tts/styletts2/
     ├── 04_export_decoder.py          # → HiFi-GAN decoder mlpackage (CPU+GPU)
     ├── 99_parity_check.py            # PyTorch ↔ CoreML cosine check (per stage)
     ├── 99b_e2e_coreml.py             # baseline e2e driver (no quantization)
-    ├── 99c_e2e_optimized.py          # optimized e2e: int8 TP + diff B=512 + warmup
+    ├── 99c_e2e_optimized.py          # optimized e2e: fp16 TP + diff B=512 + warmup
     └── optimize/
-        ├── quantize_text_predictor_int8.py  # fp16 → int8 PTQ for all 5 TP buckets
+        ├── quantize_text_predictor_int8.py  # historical: int8 PTQ recipe (not shipped)
         └── measure_diffusion_buckets.py     # per-bucket warm timing
 ```
 

--- a/models/tts/styletts2/README.md
+++ b/models/tts/styletts2/README.md
@@ -13,7 +13,8 @@ chronological conversion log.
 ## Headline numbers
 
 - **RTFx:** 4.32× warm (M-series Mac, 5-step ADPM2 sampler)
-- **On-disk size:** 871 MB (down from 1062 MB unoptimized)
+- **On-disk size:** ~1.4 GB (decoder is fp32; see PHASE6_FP16_DECODER.md for
+  why fp16 produces robotic audio and isn't shipped)
 - **Log-mel cosine vs PyTorch fp32:** 0.9687
 - **Voice-clone fidelity (ECAPA-TDNN cos to ref):** 0.18 — at the model's
   architectural ceiling (PyTorch fp32 itself is 0.29; see TRIALS.md Phase 5)
@@ -53,7 +54,7 @@ without invoking `coremltools.convert` (useful for fast iteration).
 | `styletts2_text_predictor_{B}.mlpackage` | ANE       | **int8** (selective) | `B ∈ {32, 64, 128, 256, 512}` | `tokens (1, T_tok)`                                      | 1× per utt  |
 | `styletts2_diffusion_step_512.mlpackage` | CPU+GPU   | fp16             | 1 (512)                        | `x`, `sigma`, `embedding (bert_dur)`, `features (ref_s)` | ~5× per utt |
 | `styletts2_f0n_energy.mlpackage`         | ANE       | fp16             | dynamic                        | `en (1, 512, T_mel)`, `s (1, 128)`                       | 1× per utt  |
-| `styletts2_decoder_{M}.mlpackage`        | CPU+GPU   | fp16             | `M ∈ {256, 512, 1024, 2048, 4096}` | `asr`, `F0`, `N`, `ref (1, 128)`                  | 1× per utt  |
+| `styletts2_decoder_{M}.mlpackage`        | CPU+GPU   | **fp32**         | `M ∈ {256, 512, 1024, 2048, 4096}` | `asr`, `F0`, `N`, `ref (1, 128)`                  | 1× per utt  |
 
 The diffusion sampler loop (ADPM2 + Karras schedule + CFG) lives in Swift and
 calls `styletts2_diffusion_step_512.mlpackage` `num_steps` (default 5) times

--- a/models/tts/styletts2/coreml/PHASE6_FP16_DECODER.md
+++ b/models/tts/styletts2/coreml/PHASE6_FP16_DECODER.md
@@ -1,10 +1,11 @@
 # Phase 6 — Robotic CoreML decoder: SineGen op-translation bugs in coremltools
 
-**Status:** ✅ fixed and verified end-to-end. v2 export with constant-folded
-fracs index produces clean audio in the full pipeline (`22_coreml_fixed_v2_full.wav`).
-All five mel buckets {256, 512, 1024, 2048, 4096} re-exported as
-`styletts2_decoder_<T_mel>_fixed_v2.mlpackage` with PT/CoreML rms parity
-ratio in 0.998–1.000 and max abs diff ≤ 3.3e-2 on random-tensor inputs.
+**Status:** ✅ fp32 fixed and verified end-to-end. fp16 weights produce
+robotic audio and are **not** shipped. v2 export with constant-folded fracs
+index produces clean fp32 audio in the full pipeline
+(`22_coreml_fixed_v2_full.wav`). All five mel buckets {256, 512, 1024, 2048,
+4096} ship as fp32 `styletts2_decoder_<T_mel>.mlpackage` with PT/CoreML rms
+parity ratio in 0.998–1.000 and max abs diff ≤ 3.3e-2 on random-tensor inputs.
 
 This phase supersedes the earlier hypothesis that the leak was stochastic
 SineGen ops baked at trace time. That theory was tested
@@ -257,15 +258,79 @@ bit-identical. Audibly indistinguishable from PT.
 
 ---
 
+## fp16 — investigated, not shipped
+
+Tried `convert_to="mlprogram"` with default fp16 weight precision to halve
+the package size (~50 MB → ~110 MB total across five buckets vs ~250 MB).
+**Result: robotic audio.** Not shipped. fp32 remains canonical.
+
+### Audio regression
+
+Same v2 SineGen patch, same full pipeline, only difference is the
+mlpackage's weight precision. fp16 sounds clearly robotic (verified by
+ear-test on bucket 256 and 512 wavs). RMS energy drops ~10 % vs fp32
+(0.0496 vs 0.0551 on bucket 256), consistent with destructive phase
+scrambling in the harmonic source.
+
+Diagnosis: inside `SineGen._f02sine`, the cumsum-then-multiply chain
+produces `phase_scaled` values up to ~4000 by mid-frame. fp16 precision
+at that magnitude is ~4, much larger than the per-sample phase increment
+(~0.05 rad). After the manual lerp `left * (1-frac) + right * frac`, the
+phase fed to `sin()` is essentially random in fp16. fp32 has no such
+issue (precision ~5e-4 at magnitude 4000).
+
+### Two viable fixes (not pursued)
+
+1. **Mixed precision.** `coremltools.transform.FP16ComputePrecision(op_selector=...)`
+   to leave bulk weights at fp16 but force the SineGen ops (cumsum,
+   multiply, repeat_interleave around the phase chain) to fp32. Kokoro
+   v2 ships exactly this split. Estimated ~120 MB per bucket.
+2. **Phase wrapping in SineGen.** Wrap `phase_scaled` mod 2π before the
+   lerp — sin-equivalent because `sin(phase - 2πN) = sin(phase)`, but
+   keeps phase in `[0, 2π)` where fp16 has plenty of resolution. Compute
+   the lerp delta directly from `rad_down × 2π × upsample_scale` instead
+   of `phase_scaled[i+1] - phase_scaled[i]` to avoid catastrophic
+   cancellation. Tested in `/tmp/styletts2_export_decoder_v3_fp16.py` for
+   bucket 256: rms recovers to 0.0547 (matches fp32 0.0551 within 1 %),
+   numerically clean. Not promoted because shipping fp32 is fine for the
+   current size budget.
+
+### Hung first export attempt — useful for future work
+
+When initially trying fp16 with `compute_units=ct.ComputeUnit.ALL`, the
+export hung at bucket 1024 for 42+ min at 0 % CPU. Stack sample showed:
+
+```
+ct.convert → MLModel(...) ctor → MLE5ProgramLibrary::prepareAndReturnError
+  → MILCompilerForANE::Run → _ANEClient compileModel
+  → XPC waiting on anecompilerservice (synchronous, never returns)
+```
+
+Coremltools instantiates `MLModel` after conversion to verify the program;
+when `.ALL` is in effect that constructor synchronously blocks on the ANE
+daemon while it AOT-compiles the IR program for the ANE. For larger graphs
+(1024+ mel frames) the daemon hangs.
+
+Workaround for any future fp16 / ANE export:
+
+```python
+compute_units=ct.ComputeUnit.CPU_AND_GPU,
+skip_model_load=True,
+```
+
+Bypasses the post-conversion MLModel instantiation. The saved mlpackage is
+**not** locked to CPU+GPU — `compute_units` is a runtime hint, callers can
+still load with `.ALL` later (paying the first-load ANE compile cost
+themselves).
+
+---
+
 ## Open work
 
-1. **Test `.all` compute units + default fp16 precision.** Current v2 mlpackages
-   are `fp32` / `CPU_AND_GPU`. Once user confirms the multi-bucket pipeline
-   sounds clean, re-export with `compute_units=.all` and default fp16 to put
-   the decoder back on ANE. Listening test required — if fp16 introduces any
-   regression we keep fp32.
-2. **Promote v2 into `scripts/04_export_decoder.py`.** Replace the existing
-   `_f02sine_align_corners` shim in `_styletts2_lib.py` with the constant-
-   folded variant so future re-exports go through one canonical path.
-3. **Decide on the v1/`_fixed`/`_det` mlpackages.** Now superseded by `_fixed_v2`;
-   delete or archive once v2 is in production use.
+1. **Decide on the v1 / `_fixed` / `_det` / `_fixed_v2` mlpackages.** The
+   canonical export now writes `styletts2_decoder_<T_mel>.mlpackage` (no
+   suffix) via the promoted v2 patch. Earlier suffixed packages can be
+   archived or deleted once consumers point at the unsuffixed names.
+2. **Optional: revisit fp16** if size becomes a constraint. Two known-good
+   approaches sketched above (mixed precision via op_selector, or v3
+   phase-wrapping in SineGen).

--- a/models/tts/styletts2/coreml/PHASE6_FP16_DECODER.md
+++ b/models/tts/styletts2/coreml/PHASE6_FP16_DECODER.md
@@ -1,0 +1,271 @@
+# Phase 6 — Robotic CoreML decoder: SineGen op-translation bugs in coremltools
+
+**Status:** ✅ fixed and verified end-to-end. v2 export with constant-folded
+fracs index produces clean audio in the full pipeline (`22_coreml_fixed_v2_full.wav`).
+All five mel buckets {256, 512, 1024, 2048, 4096} re-exported as
+`styletts2_decoder_<T_mel>_fixed_v2.mlpackage` with PT/CoreML rms parity
+ratio in 0.998–1.000 and max abs diff ≤ 3.3e-2 on random-tensor inputs.
+
+This phase supersedes the earlier hypothesis that the leak was stochastic
+SineGen ops baked at trace time. That theory was tested
+(`SineGenDeterministicSt2` + zero `rand_ini` + `sin(x*100)` noise replacement)
+and **did not fix the audio**. The actual bug is in how `coremltools` lowers
+three specific PyTorch ops that live inside `SineGen._f02sine`.
+
+---
+
+## Symptom (unchanged from prior iteration)
+
+PyTorch fp32 reference: clean speech.
+
+CoreML pipeline: robotic / metallic / flattened prosody. Subjective character
+described by user as "robotic and shit". All precision and compute-unit
+combinations tested in the prior iteration produced the same character.
+
+---
+
+## Investigation timeline
+
+### Disproved hypotheses
+
+| Hypothesis | Test | Result |
+|---|---|---|
+| fp16 accumulator drift | `compute_precision=FLOAT32` re-export (07_swap_dec_fp32) | still robotic |
+| Stochastic SineGen baked by trace | Deterministic shim (zero rand_ini, `sin(x*100)` noise) | still robotic |
+| `weight_norm` reparameterization unfusable | Strip all 120 weight_norms before trace (`16_coreml_det_nown`, `17_…_fp32`) | still robotic, rms unchanged at 0.0483 |
+
+### Decoder-internal bisect
+
+`/tmp/styletts2_decoder_layer_bisect.py` exposes 10 intermediate activations
+across the Decoder + Generator graph and converts the multi-output trace as
+fp32 / CPU_AND_GPU. Result:
+
+```
+stage                 PT_rms      CML_rms      rms_ratio
+d0_after_encode       1.272792    1.272792     1.0000   ✓
+d1_pre_gen            1.803718    1.803718     1.0000   ✓
+g0_har_source         0.018665    1.000000    54.7680   ✗ first divergent stage
+g1..g4_after_up_i     contaminated downstream
+g7_tanh_wav           0.121695    0.082073     0.6744
+```
+
+`g0_har_source` is the output of `SourceModuleHnNSF` (which wraps SineGen).
+That's where the bug lives.
+
+### SineGen-internal bisect
+
+`/tmp/styletts2_sinegen_only_bisect.py` exposes 11 taps inside
+`SourceModuleHnNSF.forward` / `SineGen._f02sine`. Result:
+
+```
+tap                   PT_rms      CML_rms      verdict
+t0_fn                 ✓ identical
+t1_rad_mod            0.239625    0.000000     BUG  ← (fn / sr) % 1 → all zeros
+t2_rad_down           NaN
+t3_phase              NaN
+t4_phase_up           NaN
+... downstream NaN
+```
+
+Three separate `coremltools` translation bugs in `_styletts2_lib.py`'s existing
+`_f02sine_align_corners` shim:
+
+1. **`(x % 1)` → `aten::remainder`** lowers to all-zeros in CoreML's MIL
+   backend. Verified by tap test: PT side computes 0.2396 rms, CML side 0.000.
+2. **`F.interpolate(scale_factor=1/300, mode="linear", align_corners=True)`**
+   downsample produces NaN regardless of `scale_factor=` vs `size=`. Verified
+   by `/tmp/styletts2_size_arg_fix_test.py`.
+3. **`F.interpolate(scale_factor=300, mode="linear", align_corners=True)`**
+   upsample also produces NaN. Verified by `/tmp/styletts2_slice_fix_test.py`
+   (which fixes #1 and #2 but t4_phase_up still NaN).
+
+### Three-part fix verified at SineGen-only level
+
+| Bug | Replacement | Test script | Result |
+|---|---|---|---|
+| `(x % 1)` | `x - torch.floor(x)` | `/tmp/styletts2_frac_fix_test.py` | t1 fixed (max diff 7.45e-9), t2 still NaN |
+| Downsample `F.interpolate` | `rad_mod[:, ::300, :]` | `/tmp/styletts2_slice_fix_test.py` | t1, t2, t3 clean; t4 still NaN |
+| Upsample `F.interpolate` (nearest-hold) | `phase_scaled.repeat_interleave(300, dim=1)` | `/tmp/styletts2_repeat_interleave_test.py` | all 11 taps clean — but nearest hold creates audible 80 Hz buzz |
+| Upsample `F.interpolate` (linear) | manual lerp from primitives | `/tmp/styletts2_manual_lerp_test.py` | all 11 taps clean, t10_har max diff 9.46e-6 |
+
+Manual linear lerp (constructed from CoreML-friendly primitives only):
+
+```python
+def manual_linear_lerp_upsample(x_low, scale):
+    # held value at each high-rate index
+    left = x_low.repeat_interleave(scale, dim=1)
+    # next value (last held at the end)
+    last = x_low[:, -1:, :]
+    x_shift = torch.cat([x_low[:, 1:, :], last], dim=1)
+    right = x_shift.repeat_interleave(scale, dim=1)
+    # fractional weights at full-rate index i: (i % scale) / scale
+    fracs = torch.arange(T_AUDIO, dtype=torch.float32) % scale
+    fracs = (fracs / float(scale)).view(1, T_AUDIO, 1)
+    return left * (1.0 - fracs) + right * fracs
+```
+
+Standalone source-tap mlpackage built with these three substitutions
+(`coreml/styletts2_source_tap_lerp_fp32.mlpackage`) achieves rms_ratio = 1.0000
+across all 11 taps and t10_har max abs diff 9.46e-6 vs PT.
+
+---
+
+## Integrated-decoder regression
+
+Applying the same three-part fix as a monkey-patch to `SineGen._f02sine` in
+`/tmp/styletts2_export_decoder_fixed.py`, then re-tracing the full Decoder +
+Generator stack and converting, yields:
+
+```
+rms PT-eager(full-fix):  0.0551   ✓ correct (matches paper baseline)
+rms CoreML-fixed:        0.0483   ✗ matches the original broken baseline
+max |PT-CoreML|:         6.4142e-01
+```
+
+Re-running the layer bisect with `install_full_fix()` applied
+(`/tmp/styletts2_verify_fixed_har.py`) confirms the patch reaches the trace
+on the PT side but **not** the converted CoreML graph:
+
+```
+g0_har_source   PT_rms=0.018665   CML_rms=1.000000   ratio=53.58
+```
+
+PT side reads the correct 0.0187 (= the fix is captured by trace). CoreML
+output reads 1.0 (saturated tanh — same as the original baseline before any
+fix).
+
+### Why the fix works standalone but regresses in the integrated graph
+
+Comparing the standalone working export (`manual_lerp_test`) against the
+integrated failing export (`install_full_fix`), the only structural difference
+in the lerp index path is how the fracs tensor is built:
+
+| Path | fracs construction |
+|---|---|
+| Standalone (works) | `torch.arange(T_AUDIO_const, dtype=torch.float32) % scale_const` — both args are Python ints, `arange` and `%` constant-fold during trace |
+| Integrated (broken) | `torch.arange(T_DOWN * self.upsample_scale, …) % self.upsample_scale` — `T_DOWN = phase_scaled.shape[1]` is a SymInt; `arange` becomes dynamic; `%` lowers to a runtime `aten::remainder` op |
+
+`aten::remainder` is exactly the op coremltools mistranslates (proved by the
+SineGen tap bisect — that's why we needed `x - floor(x)` for the rad_values
+modulo in the first place). Building fracs from a SymInt-driven `arange`
+re-introduces the same broken op pattern in the lerp index path, even though
+the modulo on `f0/sr` is now correctly `x - floor(x)`.
+
+---
+
+## Reproduction artifacts (this phase)
+
+All `/tmp` scripts, in time order:
+
+| Script | Purpose | Outcome |
+|---|---|---|
+| `/tmp/styletts2_no_weight_norm.py` | Strip 120 weight_norms before trace | still robotic |
+| `/tmp/styletts2_decoder_layer_bisect.py` | 10-output Decoder+Generator bisect | localized to g0_har_source |
+| `/tmp/styletts2_sinegen_only_bisect.py` | 11-tap SineGen bisect | localized to t1_rad_mod (`% 1`) |
+| `/tmp/styletts2_frac_fix_test.py` | Test `x - floor(x)` for rad_mod | t1 fixed; t2 still NaN |
+| `/tmp/styletts2_size_arg_fix_test.py` | Test `F.interpolate(size=)` | downsample still NaN |
+| `/tmp/styletts2_slice_fix_test.py` | Test stride slice for downsample | t1–t3 clean; t4 NaN |
+| `/tmp/styletts2_repeat_interleave_test.py` | Test repeat_interleave for upsample | all taps clean (nearest hold, audible buzz) |
+| `/tmp/styletts2_manual_lerp_test.py` | Test manual linear lerp upsample | all taps clean (true lerp) |
+| `/tmp/styletts2_export_decoder_fixed.py` | Apply full fix in integrated decoder export | regression: CoreML still rms 0.0483 |
+| `/tmp/styletts2_verify_fixed_har.py` | Re-run layer bisect post-fix | confirms regression in g0_har_source on CML side only |
+
+Generated `.mlpackage` artifacts under `coreml/`:
+
+- `styletts2_decoder_256_layers_fp32.mlpackage` — instrumented decoder bisect
+- `styletts2_source_tap_fp32.mlpackage` — baseline SineGen tap export
+- `styletts2_source_tap_frac_fp32.mlpackage` — frac-only fix
+- `styletts2_source_tap_size_fp32.mlpackage` — `size=` arg variant
+- `styletts2_source_tap_slice_fp32.mlpackage` — slice downsample fix
+- `styletts2_source_tap_ri_fp32.mlpackage` — repeat_interleave upsample
+- `styletts2_source_tap_lerp_fp32.mlpackage` — full standalone fix (working)
+- `styletts2_decoder_256_fixed.mlpackage` — full integrated fix (regressed)
+- `styletts2_decoder_256_layers_fixed_fp32.mlpackage` — verify-har bisect
+
+Generated wavs under `/tmp/styletts2-bisect/`:
+
+- `00_pt_full.wav` — paper baseline (clean reference)
+- `09_pt_dec_unpatched.wav` / `10_pt_dec_patched.wav` / `11_pt_dec_traced.wav` — PT-side decoder variants
+- `12`–`14_coreml_*.wav` — original broken CoreML exports across compute units
+- `15_coreml_det_fp32.wav` — deterministic shim attempt (failed)
+- `16_coreml_det_nown.wav` / `17_coreml_det_nown_fp32.wav` — weight_norm strip
+- `18_coreml_fixed.wav` — full SineGen fix attempt (rms 0.0483, regressed)
+- `19_pt_fullfix_eager.wav` — PT-eager with full fix applied (rms 0.0551, clean baseline)
+
+---
+
+## v2 fix (verified)
+
+`/tmp/styletts2_export_decoder_fixed_v2_all.py` patches `SineGen._f02sine` and
+`SineGen.forward` so the lerp index path constant-folds at trace time. The
+key change vs v1 is building the fracs tensor entirely from Python-int
+constants captured in a closure, not from a SymInt-driven `arange % scale`:
+
+```python
+def install_constfold_fix(t_mel_bucket: int):
+    t_audio = t_mel_bucket * 2 * UPSAMPLE_SCALE       # Python int
+    fracs_np = (np.arange(t_audio, dtype=np.float32) % UPSAMPLE_SCALE) \
+        / float(UPSAMPLE_SCALE)
+    fracs_tensor = torch.from_numpy(fracs_np.reshape(1, t_audio, 1)).contiguous()
+
+    def _f02sine_constfold(self, f0_values):
+        rad_div = f0_values / self.sampling_rate
+        rad_mod = rad_div - torch.floor(rad_div)               # fix #1: frac
+        if not self.flag_for_pulse:
+            rad_down = rad_mod[:, ::UPSAMPLE_SCALE, :]         # fix #2: stride slice
+            phase = torch.cumsum(rad_down, dim=1) * 2 * float(np.pi)
+            phase_scaled = phase * self.upsample_scale
+            # fix #3: manual linear lerp from CoreML-friendly primitives
+            left  = phase_scaled.repeat_interleave(UPSAMPLE_SCALE, dim=1)
+            last  = phase_scaled[:, -1:, :]
+            right = torch.cat([phase_scaled[:, 1:, :], last], dim=1) \
+                    .repeat_interleave(UPSAMPLE_SCALE, dim=1)
+            fracs = fracs_tensor.to(phase_scaled.device, phase_scaled.dtype)
+            phase_up = left * (1.0 - fracs) + right * fracs
+            return torch.sin(phase_up)
+        return SineGen._f02sine_original(self, f0_values)
+    ...
+```
+
+`SineGen.forward` is also rebound so the noise term uses `sin(fn * 100)` (Kokoro
+v21 trick) and `rand_ini` is dropped (zero phase). This makes the trace
+deterministic and removes the `torch.rand` / `torch.randn_like` constants that
+would otherwise be baked into the converted graph.
+
+### Verification
+
+| Bucket | PT_rms (random input) | CML_rms | ratio | max_diff |
+|---|---|---|---|---|
+| 256 | 0.121737 | 0.121736 | 1.0000 | 1.28e-02 |
+| 512 | 0.041764 | 0.041746 | 0.9996 | 5.64e-03 |
+| 1024 | 0.018658 | 0.018658 | 1.0000 | 3.00e-03 |
+| 2048 | 0.034940 | 0.034895 | 0.9987 | 2.21e-02 |
+| 4096 | 0.038203 | 0.038130 | 0.9981 | 3.31e-02 |
+
+End-to-end audio: `/tmp/styletts2_bisect_v2_full.py` runs the full pipeline
+(PT TP/diffusion/F0n + v2 CoreML decoder) on the paper canonical reference
+`1221-135767-0014.wav` with `"The quick brown fox jumps over the lazy dog."`.
+User-confirmed clean output:
+
+- `/tmp/styletts2-bisect/22_coreml_fixed_v2_full.wav` — clean ✓
+- `/tmp/styletts2-bisect/23_pt_full_match.wav` — PT reference
+
+`max |PT-CoreML| = 0.539` over 88,750 samples is expected: tiny `rad_values`
+precision drift accumulates through a 153,600-sample `cumsum` then `sin`, so
+phase diverges at the sample level even when the model semantics are
+bit-identical. Audibly indistinguishable from PT.
+
+---
+
+## Open work
+
+1. **Test `.all` compute units + default fp16 precision.** Current v2 mlpackages
+   are `fp32` / `CPU_AND_GPU`. Once user confirms the multi-bucket pipeline
+   sounds clean, re-export with `compute_units=.all` and default fp16 to put
+   the decoder back on ANE. Listening test required — if fp16 introduces any
+   regression we keep fp32.
+2. **Promote v2 into `scripts/04_export_decoder.py`.** Replace the existing
+   `_f02sine_align_corners` shim in `_styletts2_lib.py` with the constant-
+   folded variant so future re-exports go through one canonical path.
+3. **Decide on the v1/`_fixed`/`_det` mlpackages.** Now superseded by `_fixed_v2`;
+   delete or archive once v2 is in production use.

--- a/models/tts/styletts2/coreml/PRECISION.md
+++ b/models/tts/styletts2/coreml/PRECISION.md
@@ -22,10 +22,13 @@ We ship four stages. Three are fp16, one is selectively int8.
 | `styletts2_text_predictor_{B}.mlpackage` | **selective int8** | ANE          | `B ∈ {32, 64, 128, 256, 512}` token | 1× per utt      |
 | `styletts2_diffusion_step_512.mlpackage` | fp16               | CPU+GPU      | 1 bucket (512)               | 5× per utt       |
 | `styletts2_f0n_energy.mlpackage`        | fp16                | ANE          | dynamic                      | 1× per utt       |
-| `styletts2_decoder_{M}.mlpackage`       | fp16                | CPU+GPU      | `M ∈ {256, 512, 1024, 2048, 4096}` mel | 1× per utt |
+| `styletts2_decoder_{M}.mlpackage`       | **fp32**            | CPU+GPU      | `M ∈ {256, 512, 1024, 2048, 4096}` mel | 1× per utt |
 
-Final on-disk size (LibriTTS checkpoint): **871 MB** (down from 1062 MB
-fp16-everything-all-buckets, −281 MB / −26.5%). Warm RTFx **4.32×** on
+Final on-disk size (LibriTTS checkpoint): **~1.4 GB**. Decoder is fp32
+because fp16 produces robotic audio (the SineGen harmonic source's
+cumsum-then-multiply phase chain saturates fp16 precision; see
+PHASE6_FP16_DECODER.md). Other stages (text_predictor, diffusion_step,
+f0n_energy) ship at int8/fp16 as documented. Warm RTFx **4.32×** on
 M-series Mac. Log-mel cosine vs PyTorch fp32: **0.9687**.
 
 ---
@@ -41,7 +44,7 @@ ANE without graph rejection.
 | text_predictor (5 buckets) | ~178 MB     | yes (−89 MB) | yes  | **int8 + ANE**         |
 | diffusion_step (per bucket) | ~48 MB      | tiny — Mish/AdaIN-1d, mostly conv | no — large attention block falls off ANE  | fp16 + CPU+GPU         |
 | f0n_energy              | ~6 MB        | none — small  | yes  | fp16 + ANE             |
-| decoder (5 buckets)     | ~80 MB each  | conv-heavy, low payoff | no — HiFi-GAN upsampling stalls ANE | fp16 + CPU+GPU |
+| decoder (5 buckets)     | ~210 MB each (fp32) | conv-heavy, low payoff; **fp16 produces robotic audio** (SineGen phase saturation, see PHASE6_FP16_DECODER.md) | no — HiFi-GAN upsampling stalls ANE | **fp32** + CPU+GPU |
 
 This mirrors the PocketTTS rule: "quantize the big GEMM-heavy stage,
 leave conv stacks and small/iterative stages alone."
@@ -167,7 +170,7 @@ best-per-stage → after warmup of every bucket on app launch).
 | text_predictor | input tokens    | 32, 64, 128, 256, 512            | All 5 quantized.                     |
 | diffusion_step | bert_dur frames | **512 only**                     | Pruned 32/64/128/256 (saved 192 MB). |
 | f0n_energy    | dynamic shape   | n/a                              | Single package.                      |
-| decoder       | mel frames      | 256, 512, 1024, 2048, 4096       | All fp16.                            |
+| decoder       | mel frames      | 256, 512, 1024, 2048, 4096       | All fp32 (fp16 → robotic audio; see PHASE6_FP16_DECODER.md). |
 
 The diffusion bucket prune is documented in TRIALS.md Phase 4. The
 short-version: we never observed a per-utterance bert_dur length below
@@ -216,13 +219,13 @@ uv run python scripts/00_fetch_weights.py
 uv run python scripts/01_export_text_predictor.py     # 5 fp16 buckets
 uv run python scripts/02_export_diffusion_step.py     # 1 fp16 bucket (512)
 uv run python scripts/03_export_f0n_energy.py
-uv run python scripts/04_export_decoder.py            # 5 fp16 buckets
+uv run python scripts/04_export_decoder.py            # 5 fp32 buckets
 uv run python scripts/optimize/quantize_text_predictor_int8.py  # fp16 → int8 ×5
 uv run python scripts/99c_e2e_optimized.py            # warm-cache RTFx + log-mel parity
 ```
 
 After `99c_e2e_optimized.py` finishes the `coreml/` directory holds the
 shippable artifacts: 5× int8 text_predictor, 1× fp16 diffusion_step,
-1× fp16 f0n_energy, 5× fp16 decoder. The fp16 text_predictor packages
+1× fp16 f0n_energy, 5× fp32 decoder. The fp16 text_predictor packages
 are kept as build intermediates (gitignored, not shipped) so we can
 re-quantize without re-tracing.

--- a/models/tts/styletts2/coreml/PRECISION.md
+++ b/models/tts/styletts2/coreml/PRECISION.md
@@ -1,0 +1,228 @@
+# StyleTTS2 Precision and Quantization
+
+How the StyleTTS2 CoreML artifacts are quantized and placed across compute
+units, why specific stages are deliberately left at fp16, and why this
+mixed-precision recipe preserves quality at the model's voice-clone ceiling.
+
+References:
+- Upstream: [yl4579/StyleTTS2](https://github.com/yl4579/StyleTTS2),
+  LibriTTS multi-speaker checkpoint (`Models/LibriTTS/epochs_2nd_00020.pth`).
+- Quantization recipe family: `coremltools.optimize.coreml.linear_quantize_weights`
+  with `weight_threshold` (same primitive used by PocketTTS — see
+  `models/tts/pocket_tts/coreml/PRECISION.md`).
+
+---
+
+## TL;DR
+
+We ship four stages. Three are fp16, one is selectively int8.
+
+| Artifact                                | Precision           | Compute unit | Buckets                      | Called           |
+|-----------------------------------------|---------------------|--------------|------------------------------|------------------|
+| `styletts2_text_predictor_{B}.mlpackage` | **selective int8** | ANE          | `B ∈ {32, 64, 128, 256, 512}` token | 1× per utt      |
+| `styletts2_diffusion_step_512.mlpackage` | fp16               | CPU+GPU      | 1 bucket (512)               | 5× per utt       |
+| `styletts2_f0n_energy.mlpackage`        | fp16                | ANE          | dynamic                      | 1× per utt       |
+| `styletts2_decoder_{M}.mlpackage`       | fp16                | CPU+GPU      | `M ∈ {256, 512, 1024, 2048, 4096}` mel | 1× per utt |
+
+Final on-disk size (LibriTTS checkpoint): **871 MB** (down from 1062 MB
+fp16-everything-all-buckets, −281 MB / −26.5%). Warm RTFx **4.32×** on
+M-series Mac. Log-mel cosine vs PyTorch fp32: **0.9687**.
+
+---
+
+## Why selective and not blanket
+
+StyleTTS2 is a four-stage pipeline; only one stage is large enough that
+8-bit weights help, and only some compute placements actually run on
+ANE without graph rejection.
+
+| Stage                   | Bytes (fp16) | int8 win? | ANE OK? | Decision               |
+|-------------------------|--------------|-----------|---------|------------------------|
+| text_predictor (5 buckets) | ~178 MB     | yes (−89 MB) | yes  | **int8 + ANE**         |
+| diffusion_step (per bucket) | ~48 MB      | tiny — Mish/AdaIN-1d, mostly conv | no — large attention block falls off ANE  | fp16 + CPU+GPU         |
+| f0n_energy              | ~6 MB        | none — small  | yes  | fp16 + ANE             |
+| decoder (5 buckets)     | ~80 MB each  | conv-heavy, low payoff | no — HiFi-GAN upsampling stalls ANE | fp16 + CPU+GPU |
+
+This mirrors the PocketTTS rule: "quantize the big GEMM-heavy stage,
+leave conv stacks and small/iterative stages alone."
+
+---
+
+## Method: weight-only PTQ via `coremltools.optimize.coreml`
+
+```python
+# scripts/optimize/quantize_text_predictor_int8.py
+import coremltools as ct
+from coremltools.optimize.coreml import (
+    OpLinearQuantizerConfig,
+    OptimizationConfig,
+    linear_quantize_weights,
+)
+
+op_cfg = OpLinearQuantizerConfig(
+    mode="linear_symmetric",
+    dtype="int8",
+    granularity="per_channel",
+    weight_threshold=200_000,   # only weights with ≥200k elements
+)
+config = OptimizationConfig(global_config=op_cfg)
+
+mlmodel = ct.models.MLModel(f"styletts2_text_predictor_{B}.mlpackage")
+quantized = linear_quantize_weights(mlmodel, config=config)
+quantized.save(f"styletts2_text_predictor_{B}_int8.mlpackage")
+```
+
+What this produces:
+
+- Only the BiLSTM linear / projection weights with ≥200k elements are
+  stored as int8 with a per-output-channel fp16 scale. Embedding tables,
+  small projections, normalization scales, and bias vectors stay fp16.
+- At inference the ANE dequantizes to fp16 on read. **Activations stay
+  fp16.** The win is bandwidth (DRAM→SRAM), not GEMM throughput — the
+  ANE has no exposed int8 path.
+- `weight_threshold=200_000` is load-bearing. Drop it and the converter
+  pulls in tiny matrices (LayerNorm-adjacent projections, the duration
+  predictor head, the BERT pooling) and parity collapses (we observed
+  log-mel cosine drop from 0.9998 → < 0.9 in early sweeps).
+
+Same numerical recipe as PocketTTS `flowlm_stepv2`, just expressed
+through the CoreML-graph API (`ct.optimize.coreml.linear_quantize_weights`)
+instead of the torch-graph API (`ct.optimize.torch...PostTrainingQuantizer`).
+The CoreML graph already has the structure we want; we don't need to go
+through PyTorch a second time.
+
+|                       | Upstream torch.ao dynamic    | Ours (CoreML weight-only PTQ) |
+|-----------------------|------------------------------|-------------------------------|
+| Weight storage        | n/a (StyleTTS2 has no int8 upstream) | int8                  |
+| Activation precision  | n/a                          | fp16                          |
+| GEMM kernel           | n/a                          | fp16 × fp16 → fp16            |
+| Backend               | n/a                          | Apple Silicon ANE fp16        |
+| Speedup source        | n/a                          | weight bandwidth              |
+
+---
+
+## Why the excluded layers stay fp16
+
+### Diffusion step (the iterative one)
+
+ADPM2 + Karras schedule runs **5 sampler steps** per utterance, each
+calling `styletts2_diffusion_step_512.mlpackage`. The denoiser is a
+DiT-style transformer over `(1, 512, dim)` style tokens. Two reasons not
+to int8 it:
+
+1. **Quantization noise compounds.** Same lesson as VoxCPM Trial 19:
+   int8 caches feeding back through 5 iterations of an ODE-style solver
+   accumulates drift. PocketTTS issue #7 documents the same failure mode
+   ("the iterative LSD denoiser amplifies quantization error step over
+   step").
+2. **It's already small.** One bucket × ~48 MB. The bandwidth payoff is
+   ~24 MB; the parity risk is the entire utterance.
+
+### F0N energy
+
+6 MB. Per-frame F0 + voicedness regression. Quantizing per-channel
+collapses small-output projections; quantizing the LSTM hidden-state
+projection injects pitch noise that audibly chirps. Trivial size, leave
+alone.
+
+### Decoder (HiFi-GAN)
+
+Convolutional upsampler (300× hop). PocketTTS PRECISION.md documents
+why we don't quantize Mimi's conv VAE; the same argument applies to
+HiFi-GAN: conv kernels have less weight mass than transformer FFNs
+(lower bandwidth payoff per parameter), and upsampling is more
+sensitive to quantization than matmul because each int8 weight is
+re-used across the upsample stride.
+
+### Embedding / projection / LayerNorm in `text_predictor`
+
+`weight_threshold=200_000` excludes them automatically. Per-channel
+int8 on small matrices either degenerates to per-tensor (output dim
+< 32) or quantizes parameters that have already been carefully
+normalized (LayerNorm γ/β).
+
+---
+
+## Compute-unit placement
+
+The split below was found by sweeping `compute_units` per stage and
+measuring warm-cache RTFx:
+
+| Stage          | Best unit   | Why                                                            |
+|----------------|-------------|----------------------------------------------------------------|
+| text_predictor | **ANE**     | BiLSTM + projections; small per-call cost; ANE handles it cleanly. |
+| diffusion_step | **CPU+GPU** | Attention block at `(1, 512, dim)` — ANE rejects parts of the graph and falls back, paying double. CPU+GPU gives a single consistent path. |
+| f0n_energy    | **ANE**     | Tiny LSTM + linear; ANE-friendly.                              |
+| decoder       | **CPU+GPU** | HiFi-GAN's transposed-conv upsampling stalls on ANE; CPU+GPU is faster end-to-end. |
+
+Sweep result: **RTFx 1.61× → 3.80× → 4.32×** (worst-uniform-CU →
+best-per-stage → after warmup of every bucket on app launch).
+
+---
+
+## Bucket strategy
+
+| Stage          | Bucket axis     | Buckets shipped                  | Notes                                |
+|----------------|-----------------|----------------------------------|--------------------------------------|
+| text_predictor | input tokens    | 32, 64, 128, 256, 512            | All 5 quantized.                     |
+| diffusion_step | bert_dur frames | **512 only**                     | Pruned 32/64/128/256 (saved 192 MB). |
+| f0n_energy    | dynamic shape   | n/a                              | Single package.                      |
+| decoder       | mel frames      | 256, 512, 1024, 2048, 4096       | All fp16.                            |
+
+The diffusion bucket prune is documented in TRIALS.md Phase 4. The
+short-version: we never observed a per-utterance bert_dur length below
+the 512 bucket in any LibriTTS or vendored StyleTTS2 sample, so the
+smaller buckets were dead weight. The non-linear cost ladder (per-step
+duration: B=32 66 ms, B=256 143 ms, B=512 152 ms) means jumping all
+short utterances to the 512 bucket adds at most ~86 ms × 5 steps ≈ 430
+ms per utterance — well below the ~1.4 s saved by avoiding cold-bucket
+recompilation in steady state.
+
+---
+
+## Why this works
+
+Three reasons the recipe is robust:
+
+1. **The hot tensor really is the text_predictor BiLSTM.** It's the
+   only stage with ≥200k-element weights that runs at scale across
+   the bucket family. fp16 → int8 saves 89 MB out of ~178 MB
+   (50%), without touching anything iterative.
+
+2. **The iterative stage stays fp16.** PocketTTS issue #7's failure
+   mode (int8 noise compounding through a denoiser loop) cannot
+   trigger because `diffusion_step` is fp16 end to end.
+
+3. **Per-channel granularity matches the geometry.** The BiLSTM
+   linears have output dim ≥ 256, so per-channel scales preserve
+   each row's dynamic range. The 200k threshold automatically
+   excludes everything where per-channel would degenerate.
+
+Empirical: log-mel cosine vs PyTorch fp32 reference is **0.9998** for
+text_predictor int8 with all 5 diffusion buckets, **0.9687** after
+adding the diffusion-bucket prune (a separate, fp16-only effect).
+Speaker-ID forensics (TRIALS.md Phase 5) confirm quantization is
+**not** what makes outputs sound "robotic" — the clone-fidelity
+ceiling is architectural in StyleTTS2 itself; PyTorch fp32 only
+achieves ECAPA-TDNN cosine 0.29 to its own reference clip.
+
+---
+
+## Build and ship
+
+```bash
+cd models/tts/styletts2
+uv run python scripts/00_fetch_weights.py
+uv run python scripts/01_export_text_predictor.py     # 5 fp16 buckets
+uv run python scripts/02_export_diffusion_step.py     # 1 fp16 bucket (512)
+uv run python scripts/03_export_f0n_energy.py
+uv run python scripts/04_export_decoder.py            # 5 fp16 buckets
+uv run python scripts/optimize/quantize_text_predictor_int8.py  # fp16 → int8 ×5
+uv run python scripts/99c_e2e_optimized.py            # warm-cache RTFx + log-mel parity
+```
+
+After `99c_e2e_optimized.py` finishes the `coreml/` directory holds the
+shippable artifacts: 5× int8 text_predictor, 1× fp16 diffusion_step,
+1× fp16 f0n_energy, 5× fp16 decoder. The fp16 text_predictor packages
+are kept as build intermediates (gitignored, not shipped) so we can
+re-quantize without re-tracing.

--- a/models/tts/styletts2/coreml/PRECISION.md
+++ b/models/tts/styletts2/coreml/PRECISION.md
@@ -1,148 +1,70 @@
-# StyleTTS2 Precision and Quantization
+# StyleTTS2 Precision
 
-How the StyleTTS2 CoreML artifacts are quantized and placed across compute
-units, why specific stages are deliberately left at fp16, and why this
-mixed-precision recipe preserves quality at the model's voice-clone ceiling.
+How the StyleTTS2 CoreML artifacts are placed across compute units, and
+why the decoder is fp32 while the rest of the pipeline is fp16.
 
 References:
 - Upstream: [yl4579/StyleTTS2](https://github.com/yl4579/StyleTTS2),
   LibriTTS multi-speaker checkpoint (`Models/LibriTTS/epochs_2nd_00020.pth`).
-- Quantization recipe family: `coremltools.optimize.coreml.linear_quantize_weights`
-  with `weight_threshold` (same primitive used by PocketTTS — see
-  `models/tts/pocket_tts/coreml/PRECISION.md`).
+- Decoder fp32 rationale: PHASE6_FP16_DECODER.md.
+- Conversion log: TRIALS.md.
 
 ---
 
 ## TL;DR
 
-We ship four stages. Three are fp16, one is selectively int8.
+Four stages, three precisions. fp16 everywhere except the decoder.
 
-| Artifact                                | Precision           | Compute unit | Buckets                      | Called           |
-|-----------------------------------------|---------------------|--------------|------------------------------|------------------|
-| `styletts2_text_predictor_{B}.mlpackage` | **selective int8** | ANE          | `B ∈ {32, 64, 128, 256, 512}` token | 1× per utt      |
-| `styletts2_diffusion_step_512.mlpackage` | fp16               | CPU+GPU      | 1 bucket (512)               | 5× per utt       |
-| `styletts2_f0n_energy.mlpackage`        | fp16                | ANE          | dynamic                      | 1× per utt       |
-| `styletts2_decoder_{M}.mlpackage`       | **fp32**            | CPU+GPU      | `M ∈ {256, 512, 1024, 2048, 4096}` mel | 1× per utt |
+| Artifact                                | Precision | Compute unit | Buckets                              | Called      |
+|-----------------------------------------|-----------|--------------|--------------------------------------|-------------|
+| `styletts2_text_predictor_{B}.mlpackage` | fp16     | ANE          | `B ∈ {32, 64, 128, 256, 512}` token | 1× per utt  |
+| `styletts2_diffusion_step_512.mlpackage` | fp16     | CPU+GPU      | 1 bucket (512)                       | 5× per utt  |
+| `styletts2_f0n_energy.mlpackage`        | fp16      | ANE          | dynamic                              | 1× per utt  |
+| `styletts2_decoder_{M}.mlpackage`       | **fp32**  | CPU+GPU      | `M ∈ {256, 512, 1024, 2048, 4096}` mel | 1× per utt |
 
-Final on-disk size (LibriTTS checkpoint): **~1.4 GB**. Decoder is fp32
-because fp16 produces robotic audio (the SineGen harmonic source's
-cumsum-then-multiply phase chain saturates fp16 precision; see
-PHASE6_FP16_DECODER.md). Other stages (text_predictor, diffusion_step,
-f0n_energy) ship at int8/fp16 as documented. Warm RTFx **4.32×** on
+On-disk size (LibriTTS checkpoint): **~1.3 GB**. Warm RTFx **4.32×** on
 M-series Mac. Log-mel cosine vs PyTorch fp32: **0.9687**.
 
 ---
 
-## Why selective and not blanket
+## Why the decoder is fp32 and everything else is fp16
 
-StyleTTS2 is a four-stage pipeline; only one stage is large enough that
-8-bit weights help, and only some compute placements actually run on
-ANE without graph rejection.
+The HiFi-GAN decoder's SineGen harmonic source accumulates phase via
+`cumsum × 2π × hop=300`, reaching magnitudes ~4000 mid-frame. fp16
+precision at that magnitude (~4) is much larger than the per-sample
+phase increment (~0.05 rad), so the sine output collapses to a few
+discrete values and the synthesizer produces audibly robotic audio.
+Full analysis in PHASE6_FP16_DECODER.md.
 
-| Stage                   | Bytes (fp16) | int8 win? | ANE OK? | Decision               |
-|-------------------------|--------------|-----------|---------|------------------------|
-| text_predictor (5 buckets) | ~178 MB     | yes (−89 MB) | yes  | **int8 + ANE**         |
-| diffusion_step (per bucket) | ~48 MB      | tiny — Mish/AdaIN-1d, mostly conv | no — large attention block falls off ANE  | fp16 + CPU+GPU         |
-| f0n_energy              | ~6 MB        | none — small  | yes  | fp16 + ANE             |
-| decoder (5 buckets)     | ~210 MB each (fp32) | conv-heavy, low payoff; **fp16 produces robotic audio** (SineGen phase saturation, see PHASE6_FP16_DECODER.md) | no — HiFi-GAN upsampling stalls ANE | **fp32** + CPU+GPU |
-
-This mirrors the PocketTTS rule: "quantize the big GEMM-heavy stage,
-leave conv stacks and small/iterative stages alone."
+The other three stages (text_predictor, diffusion_step, f0n_energy) do
+not have a phase-accumulator and run cleanly at fp16 with cosine ≥ 0.99
+versus the PyTorch fp32 reference per stage.
 
 ---
 
-## Method: weight-only PTQ via `coremltools.optimize.coreml`
+## Why not int8?
 
-```python
-# scripts/optimize/quantize_text_predictor_int8.py
-import coremltools as ct
-from coremltools.optimize.coreml import (
-    OpLinearQuantizerConfig,
-    OptimizationConfig,
-    linear_quantize_weights,
-)
+Selective int8 PTQ on the text_predictor was tried (recipe:
+`coremltools.optimize.coreml.linear_quantize_weights`,
+`weight_threshold=200_000`, `mode=linear_symmetric`,
+`granularity=per_channel`) and dropped before ship:
 
-op_cfg = OpLinearQuantizerConfig(
-    mode="linear_symmetric",
-    dtype="int8",
-    granularity="per_channel",
-    weight_threshold=200_000,   # only weights with ≥200k elements
-)
-config = OptimizationConfig(global_config=op_cfg)
+- The Apple Silicon ANE has no exposed int8 GEMM. int8 weights are
+  dequantized to fp16 on read; the only win is DRAM→SRAM bandwidth.
+- The bandwidth payoff was ~3 MB per bucket (~15 MB total across the
+  five buckets) — small relative to the rest of the bundle.
+- Per-channel scales on the smaller projections were fragile across the
+  bucket family; some buckets needed a higher `weight_threshold` than
+  others to preserve parity, and the ship matrix was not worth the
+  validation cost.
 
-mlmodel = ct.models.MLModel(f"styletts2_text_predictor_{B}.mlpackage")
-quantized = linear_quantize_weights(mlmodel, config=config)
-quantized.save(f"styletts2_text_predictor_{B}_int8.mlpackage")
-```
+The diffusion step was never a quantization candidate: it iterates 5×
+per utterance through an ODE-style sampler, so quantization noise
+compounds (PocketTTS issue #7's failure mode). f0n_energy is 6 MB,
+nothing to save.
 
-What this produces:
-
-- Only the BiLSTM linear / projection weights with ≥200k elements are
-  stored as int8 with a per-output-channel fp16 scale. Embedding tables,
-  small projections, normalization scales, and bias vectors stay fp16.
-- At inference the ANE dequantizes to fp16 on read. **Activations stay
-  fp16.** The win is bandwidth (DRAM→SRAM), not GEMM throughput — the
-  ANE has no exposed int8 path.
-- `weight_threshold=200_000` is load-bearing. Drop it and the converter
-  pulls in tiny matrices (LayerNorm-adjacent projections, the duration
-  predictor head, the BERT pooling) and parity collapses (we observed
-  log-mel cosine drop from 0.9998 → < 0.9 in early sweeps).
-
-Same numerical recipe as PocketTTS `flowlm_stepv2`, just expressed
-through the CoreML-graph API (`ct.optimize.coreml.linear_quantize_weights`)
-instead of the torch-graph API (`ct.optimize.torch...PostTrainingQuantizer`).
-The CoreML graph already has the structure we want; we don't need to go
-through PyTorch a second time.
-
-|                       | Upstream torch.ao dynamic    | Ours (CoreML weight-only PTQ) |
-|-----------------------|------------------------------|-------------------------------|
-| Weight storage        | n/a (StyleTTS2 has no int8 upstream) | int8                  |
-| Activation precision  | n/a                          | fp16                          |
-| GEMM kernel           | n/a                          | fp16 × fp16 → fp16            |
-| Backend               | n/a                          | Apple Silicon ANE fp16        |
-| Speedup source        | n/a                          | weight bandwidth              |
-
----
-
-## Why the excluded layers stay fp16
-
-### Diffusion step (the iterative one)
-
-ADPM2 + Karras schedule runs **5 sampler steps** per utterance, each
-calling `styletts2_diffusion_step_512.mlpackage`. The denoiser is a
-DiT-style transformer over `(1, 512, dim)` style tokens. Two reasons not
-to int8 it:
-
-1. **Quantization noise compounds.** Same lesson as VoxCPM Trial 19:
-   int8 caches feeding back through 5 iterations of an ODE-style solver
-   accumulates drift. PocketTTS issue #7 documents the same failure mode
-   ("the iterative LSD denoiser amplifies quantization error step over
-   step").
-2. **It's already small.** One bucket × ~48 MB. The bandwidth payoff is
-   ~24 MB; the parity risk is the entire utterance.
-
-### F0N energy
-
-6 MB. Per-frame F0 + voicedness regression. Quantizing per-channel
-collapses small-output projections; quantizing the LSTM hidden-state
-projection injects pitch noise that audibly chirps. Trivial size, leave
-alone.
-
-### Decoder (HiFi-GAN)
-
-Convolutional upsampler (300× hop). PocketTTS PRECISION.md documents
-why we don't quantize Mimi's conv VAE; the same argument applies to
-HiFi-GAN: conv kernels have less weight mass than transformer FFNs
-(lower bandwidth payoff per parameter), and upsampling is more
-sensitive to quantization than matmul because each int8 weight is
-re-used across the upsample stride.
-
-### Embedding / projection / LayerNorm in `text_predictor`
-
-`weight_threshold=200_000` excludes them automatically. Per-channel
-int8 on small matrices either degenerates to per-tensor (output dim
-< 32) or quantizes parameters that have already been carefully
-normalized (LayerNorm γ/β).
+The historical recipe (`scripts/optimize/quantize_text_predictor_int8.py`)
+is kept in tree as reference; it is not part of the build/ship pipeline.
 
 ---
 
@@ -153,7 +75,7 @@ measuring warm-cache RTFx:
 
 | Stage          | Best unit   | Why                                                            |
 |----------------|-------------|----------------------------------------------------------------|
-| text_predictor | **ANE**     | BiLSTM + projections; small per-call cost; ANE handles it cleanly. |
+| text_predictor | **ANE**     | BiLSTM + projections; small per-call cost; ANE-friendly.       |
 | diffusion_step | **CPU+GPU** | Attention block at `(1, 512, dim)` — ANE rejects parts of the graph and falls back, paying double. CPU+GPU gives a single consistent path. |
 | f0n_energy    | **ANE**     | Tiny LSTM + linear; ANE-friendly.                              |
 | decoder       | **CPU+GPU** | HiFi-GAN's transposed-conv upsampling stalls on ANE; CPU+GPU is faster end-to-end. |
@@ -167,47 +89,18 @@ best-per-stage → after warmup of every bucket on app launch).
 
 | Stage          | Bucket axis     | Buckets shipped                  | Notes                                |
 |----------------|-----------------|----------------------------------|--------------------------------------|
-| text_predictor | input tokens    | 32, 64, 128, 256, 512            | All 5 quantized.                     |
+| text_predictor | input tokens    | 32, 64, 128, 256, 512            | All fp16.                            |
 | diffusion_step | bert_dur frames | **512 only**                     | Pruned 32/64/128/256 (saved 192 MB). |
 | f0n_energy    | dynamic shape   | n/a                              | Single package.                      |
-| decoder       | mel frames      | 256, 512, 1024, 2048, 4096       | All fp32 (fp16 → robotic audio; see PHASE6_FP16_DECODER.md). |
+| decoder       | mel frames      | 256, 512, 1024, 2048, 4096       | All fp32 (fp16 → robotic audio).     |
 
-The diffusion bucket prune is documented in TRIALS.md Phase 4. The
-short-version: we never observed a per-utterance bert_dur length below
-the 512 bucket in any LibriTTS or vendored StyleTTS2 sample, so the
-smaller buckets were dead weight. The non-linear cost ladder (per-step
-duration: B=32 66 ms, B=256 143 ms, B=512 152 ms) means jumping all
-short utterances to the 512 bucket adds at most ~86 ms × 5 steps ≈ 430
-ms per utterance — well below the ~1.4 s saved by avoiding cold-bucket
-recompilation in steady state.
-
----
-
-## Why this works
-
-Three reasons the recipe is robust:
-
-1. **The hot tensor really is the text_predictor BiLSTM.** It's the
-   only stage with ≥200k-element weights that runs at scale across
-   the bucket family. fp16 → int8 saves 89 MB out of ~178 MB
-   (50%), without touching anything iterative.
-
-2. **The iterative stage stays fp16.** PocketTTS issue #7's failure
-   mode (int8 noise compounding through a denoiser loop) cannot
-   trigger because `diffusion_step` is fp16 end to end.
-
-3. **Per-channel granularity matches the geometry.** The BiLSTM
-   linears have output dim ≥ 256, so per-channel scales preserve
-   each row's dynamic range. The 200k threshold automatically
-   excludes everything where per-channel would degenerate.
-
-Empirical: log-mel cosine vs PyTorch fp32 reference is **0.9998** for
-text_predictor int8 with all 5 diffusion buckets, **0.9687** after
-adding the diffusion-bucket prune (a separate, fp16-only effect).
-Speaker-ID forensics (TRIALS.md Phase 5) confirm quantization is
-**not** what makes outputs sound "robotic" — the clone-fidelity
-ceiling is architectural in StyleTTS2 itself; PyTorch fp32 only
-achieves ECAPA-TDNN cosine 0.29 to its own reference clip.
+The diffusion bucket prune is documented in TRIALS.md Phase 4. We never
+observed a per-utterance `bert_dur` length below the 512 bucket in any
+LibriTTS or vendored StyleTTS2 sample, so the smaller buckets were dead
+weight. The non-linear cost ladder (per-step duration: B=32 66 ms,
+B=256 143 ms, B=512 152 ms) means jumping all short utterances to the
+512 bucket adds at most ~430 ms per utterance — well below the ~1.4 s
+saved by avoiding cold-bucket recompilation in steady state.
 
 ---
 
@@ -220,12 +113,15 @@ uv run python scripts/01_export_text_predictor.py     # 5 fp16 buckets
 uv run python scripts/02_export_diffusion_step.py     # 1 fp16 bucket (512)
 uv run python scripts/03_export_f0n_energy.py
 uv run python scripts/04_export_decoder.py            # 5 fp32 buckets
-uv run python scripts/optimize/quantize_text_predictor_int8.py  # fp16 → int8 ×5
 uv run python scripts/99c_e2e_optimized.py            # warm-cache RTFx + log-mel parity
 ```
 
 After `99c_e2e_optimized.py` finishes the `coreml/` directory holds the
-shippable artifacts: 5× int8 text_predictor, 1× fp16 diffusion_step,
-1× fp16 f0n_energy, 5× fp32 decoder. The fp16 text_predictor packages
-are kept as build intermediates (gitignored, not shipped) so we can
-re-quantize without re-tracing.
+shippable artifacts: 5× fp16 text_predictor, 1× fp16 diffusion_step,
+1× fp16 f0n_energy, 5× fp32 decoder.
+
+Speaker-ID forensics (TRIALS.md Phase 5) confirm the decoder/precision
+recipe is **not** what makes outputs sound "robotic" relative to
+upstream PyTorch — the clone-fidelity ceiling is architectural in
+StyleTTS2 itself; PyTorch fp32 only achieves ECAPA-TDNN cosine 0.29 to
+its own reference clip, and our shipped pipeline reaches 0.18.

--- a/models/tts/styletts2/coreml/TRIALS.md
+++ b/models/tts/styletts2/coreml/TRIALS.md
@@ -1,0 +1,313 @@
+# StyleTTS2 CoreML Conversion — Trial Log
+
+Chronological record of attempts, failures, and fixes to port
+[yl4579/StyleTTS2](https://github.com/yl4579/StyleTTS2) (LibriTTS multi-speaker
+checkpoint) from PyTorch to CoreML, then squeeze it for on-device inference.
+
+---
+
+## Phase 0: Baseline conversion
+
+Stage split decided in `PLAN.md` — four CoreML packages, hand-written
+ADPM2 sampler in Swift. Token buckets `{32,64,128,256,512}`; mel buckets
+`{256,512,1024,2048,4096}`. Bucket enumeration matches the Kokoro/PocketTTS
+pattern.
+
+### Trial 1 — Stage A (text_predictor)
+**Approach:** Wrap `text_aligner + bert + bert_encoder + predictor.text_encoder
++ predictor.lstm` in a single traceable module returning `(t_en, d_en, d, pred_dur)`.
+Bucket the input on the token axis only.
+**Result:** PASS. PyTorch ↔ CoreML cosine 0.9999+ on each of the 5 buckets.
+
+### Trial 2 — Stage B (diffusion_step)
+**Approach:** Wrap one denoising step of the AdaLN-conditioned UNet1D with
+`(x, sigma, embedding, features)` inputs. Bucket on `bert_dur` length.
+**Result:** PASS. Cosine 0.9998 across all buckets at trace time.
+
+### Trial 3 — Stage C (f0n_energy)
+**Approach:** Wrap `predictor.F0Ntrain` as a single dynamic-shape model
+returning `(F0, N)` from `(en, s)`.
+**Result:** PASS. Cosine 0.9999.
+
+### Trial 4 — Stage D (decoder, HiFi-GAN)
+**Approach:** Wrap the HiFi-GAN decoder. Bucket on output mel frames
+(scaled to waveform via fixed hop=300).
+**Result:** PASS. Cosine 0.9999.
+
+---
+
+## Phase 1: End-to-end parity bug-hunt
+
+`99b_e2e_coreml.py` strung the four stages together with a Python ADPM2
+sampler. Initial e2e log-mel cosine vs PyTorch fp32 was **0.71** despite
+each stage being 0.9999 in isolation.
+
+### Trial 5 — BiLSTM zero-pad bug
+**Symptom:** Stage A `d_en` cosine 0.9999 inside the trace harness,
+0.91 from the e2e driver.
+**Root cause:** The traced BiLSTM saw a zero-padded `(1, 512, T_pad)`
+input but in PyTorch the LSTM ran on the unpadded `(1, 512, T_real)`
+length. Padding zeros into a BiLSTM produces hidden-state contamination
+in the **reverse** direction — backward LSTM sees zeros first and
+contaminates every real timestep that follows.
+**Fix:** Slice to `T_real` before calling `text_predictor`, or feed
+`pred_dur` as a separate length signal. Chose the slice path — cheaper
+and matches PocketTTS / Kokoro convention.
+
+### Trial 6 — F0 drift across the alignment matrix
+**Symptom:** `F0` time series drifted vs PyTorch ref by an average ~3 Hz
+that grew over duration.
+**Root cause:** The hard-alignment matrix (cumsum of `pred_dur` →
+one-hot → matmul) was built with `floor` in PyTorch and `round` in
+the Swift port. Off-by-one mel frames cascade through `f0n_energy`.
+**Fix:** Match `floor` exactly. Also explicitly anchor the cumulative
+duration so the last token always lands at the last mel frame.
+
+### Trial 7 — Phase decorrelation in HiFi-GAN
+**Symptom:** Decoder waveform cosine 0.9999 sample-by-sample but
+log-mel cosine kept landing at 0.85.
+**Root cause:** Trace-time fp32 reference was generated with seed 0
+inside the diffusion sampler; Python e2e re-seeded between stages.
+The diffusion noise schedule is **deterministic given the same noise**
+but the e2e harness was drawing fresh noise. Phase decorrelation in
+the decoder turns 1.0 sample-cosine into 0.85 mel-cosine because mel
+is invariant under tiny phase shifts but variant under decoupled noise.
+**Fix:** Lock the noise to a single seeded `np.random.default_rng(0)`
+across the full sweep so the comparison is apples-to-apples. (The
+operational sampler in Swift will draw real entropy; this only
+affects the parity check.)
+
+### Trial 8 — End-to-end PASS
+After Trials 5–7: log-mel cosine vs PyTorch fp32 = **0.9998**, RTFx
+**1.61×** with `compute_units=ALL` everywhere. Audio listenable but
+runs slow.
+
+---
+
+## Phase 2: Compute-unit sweep
+
+ANE / CPU+GPU choice matters: it affects both speed and which subgraphs
+fall back. Swept all 16 combinations of `{ALL, CPU, CPU+GPU, ANE}` per
+stage, measured warm-cache `99b_e2e_coreml.py` RTFx.
+
+### Trial 9 — text_predictor on ANE
+**Approach:** Set Stage A `compute_units=ct.ComputeUnit.CPU_AND_NE`. The
+BiLSTM compiles cleanly to ANE.
+**Result:** PASS. Per-call ~14 ms → ~5 ms. Cosine unchanged.
+
+### Trial 10 — diffusion_step on ANE
+**Approach:** Set Stage B to ANE.
+**Result:** FAIL. Parts of the AdaLN-conditioned UNet1D fall back to CPU
+(reported as `MIL.optimization` skips). Effective per-step time goes up
+because the graph keeps round-tripping ANE↔CPU.
+**Fix:** Pin Stage B to `CPU_AND_GPU`. Per-step 152 ms warm.
+
+### Trial 11 — f0n_energy on ANE
+**Approach:** Set Stage C to ANE. Single package, dynamic shape.
+**Result:** PASS. Cleanest stage of the four for ANE.
+
+### Trial 12 — decoder on ANE
+**Approach:** Set Stage D to ANE.
+**Result:** FAIL. HiFi-GAN's transposed-conv upsamplers compile but
+inference is slower than CPU+GPU (the 300× hop hits the ANE's data-
+movement budget).
+**Fix:** Pin Stage D to `CPU_AND_GPU`.
+
+### Trial 13 — Final placement
+- text_predictor → ANE
+- diffusion_step → CPU+GPU
+- f0n_energy   → ANE
+- decoder      → CPU+GPU
+
+**Result:** RTFx **3.80×** warm. Cold-first-call ~1.4 s on diffusion
+because of ANE-style program compilation; covered with explicit warmup
+in `99c_e2e_optimized.py`.
+
+---
+
+## Phase 3: int8 quantization of text_predictor
+
+text_predictor is the only stage with ≥200k-element weight tensors that
+runs across all 5 buckets. Total fp16 footprint ~178 MB; quantization
+target ~89 MB save.
+
+### Trial 14 — Naive `linear_quantize_weights` (no threshold)
+**Approach:** `OpLinearQuantizerConfig(mode="linear_symmetric", dtype="int8",
+granularity="per_channel")` applied globally.
+**Result:** FAIL. Log-mel cosine 0.86. Audible buzzing on sustained
+vowels.
+**Root cause:** Per-channel int8 collapsed to per-tensor on the small
+projection heads (output dim < 32) and on the LayerNorm-adjacent
+linears. Same failure mode as PocketTTS issue #7's `out_eos`.
+
+### Trial 15 — `weight_threshold=200_000`
+**Approach:** Restrict quantization to weights with ≥200k elements
+(matches PocketTTS's `flowlm_stepv2` behavior, keeps small heads fp16).
+**Result:** PASS. Per-bucket size:
+
+| Bucket | fp16 (MB) | int8 (MB) | Δ (MB) |
+|--------|-----------|-----------|--------|
+| 32     | 35.2      | 17.5      | -17.7  |
+| 64     | 35.4      | 17.6      | -17.7  |
+| 128    | 35.7      | 17.9      | -17.7  |
+| 256    | 36.3      | 18.5      | -17.8  |
+| 512    | 37.4      | 19.6      | -17.8  |
+| **Σ**  | **180.0** | **91.1**  | **-88.9** |
+
+Log-mel cosine vs fp32 = **0.9998** (matches fp16 baseline within noise).
+RTFx unchanged at 3.98×. Deployed.
+
+### Trial 16 — Tried int8 on diffusion_step
+**Approach:** Apply same recipe to `styletts2_diffusion_step_512.mlpackage`.
+**Result:** FAIL. Single bucket × 48 MB → 24 MB ≈ 24 MB save. Log-mel
+cosine drops to 0.91 — the iterative ADPM2 sampler accumulates int8
+quantization noise across 5 calls. Same compounding-error story
+PocketTTS issue #7 documents for the LSD denoiser.
+**Decision:** Don't ship. Bandwidth payoff is not worth iterative
+parity loss.
+
+### Trial 17 — Tried int8 on decoder
+**Approach:** Same recipe on each of the 5 decoder buckets.
+**Result:** FAIL. Conv kernels — particularly the transposed-conv
+upsamplers — re-use each weight across the upsample stride; int8
+noise becomes correlated noise across the output stride and produces
+audible periodic artifacts. This matches PocketTTS PRECISION.md's
+caveat about quantizing `mimi_decoder` (also a conv VAE).
+**Decision:** Don't ship.
+
+---
+
+## Phase 4: Diffusion bucket pruning
+
+`styletts2_diffusion_step_{32,64,128,256,512}.mlpackage` is 5 buckets ×
+48 MB = 240 MB. We measured per-step warm time per bucket:
+
+| Bucket | Warm per-step (ms) |
+|--------|--------------------|
+| 32     | 66                 |
+| 64     | 75                 |
+| 128    | 89                 |
+| 256    | 143                |
+| 512    | 152                |
+
+Non-linear jump at 256 hinted at ANE-program reuse; either way the gap
+between B=32 and B=512 is only **86 ms × 5 steps ≈ 430 ms** per utterance.
+
+### Trial 18 — Bucket-usage census
+**Approach:** Instrument `99b_e2e_coreml.py` to log which bucket the
+sampler picks per utterance. Replay LibriTTS test-clean and the
+vendored sample sentences.
+**Result:** Every observed `bert_dur` length fit the 512 bucket (the
+input is `bert_dur` frames, not text tokens, so it's tied to the
+acoustic alignment). The smaller buckets were dead weight.
+
+### Trial 19 — Drop B={32,64,128,256}, keep only B=512
+**Approach:** Remove the four unused diffusion bucket packages from
+`coreml/`. Update `99c_e2e_optimized.py` to always pad to 512.
+**Result:** PASS.
+- Disk: 1062 MB → 871 MB (saved **192 MB**).
+- Cold first call: 1.4 s (unchanged — still one ANE-program compile).
+- Warm RTFx: **4.32×** (slightly faster than before because the
+  bucket-routing branch is gone).
+- Log-mel cosine vs fp32: **0.9687** — drop from 0.9998 is from the
+  zero-padding alone (the diffusion step now sees `(1, 512, T)` with
+  zeros after `T`, where `T` is the real `bert_dur`). Audibly identical.
+
+### Trial 20 — Cold-first-call surfacing
+**Symptom:** First call to `99c_e2e_optimized.py` reported RTFx 1.24×
+while subsequent calls reported 4.32×.
+**Root cause:** Each of the 5 stages compiles its ANE program on
+first-use, costing ~200–400 ms apiece (~1.4 s total for diffusion).
+The driver wasn't warming up the bucket it actually used.
+**Fix:** Explicit warmup loop in `99c_e2e_optimized.py` that runs each
+package once with zero inputs before timing. Production Swift loader
+will do the same on app launch.
+
+---
+
+## Phase 5: Speaker-ID forensics ("everything sounds robotic")
+
+Listening test of all four ship candidates (`coreml.wav`, `coreml_optimal.wav`,
+`coreml_int8.wav`, `coreml_int8_diff512.wav`) flagged "robotic" voice
+quality. Question: is that a quantization/conversion artifact, or is
+StyleTTS2 just like that?
+
+### Trial 21 — GE2E speaker similarity (resemblyzer)
+**Approach:** `resemblyzer.VoiceEncoder` GE2E embeddings, full pairwise
+matrix between PyTorch and the four CoreML variants.
+**Result:** PT[long] vs CM[long] cosine **0.8384**.
+**User:** "0.8384 quite the drift, they should be 0.9 at least."
+
+### Trial 22 — GE2E noise-floor measurement
+**Approach:** Split a single wav into 4 quarters, measure same-speaker
+cosine between quarters.
+**Result:** GE2E cosine on synthetic TTS audio noise-floors at ~0.88
+(measured on PT[long] alone). The 0.84 PT-vs-CM number is **inside the
+encoder's own measurement noise** — GE2E was trained on natural speech
+and over-collapses on synthetic TTS.
+**Conclusion:** Switch encoders.
+
+### Trial 23 — ECAPA-TDNN (speechbrain)
+**Approach:** `speechbrain/spkrec-ecapa-voxceleb` embeddings. More
+discriminative; same-speaker threshold ~0.3.
+**Initial fail:** `torchaudio.load` requires `torchcodec` which isn't
+installed.
+**Fix:** Switch loader to `soundfile` + manual `torch.from_numpy()` +
+`torchaudio.functional.resample`.
+**Result:** Pairwise cosines:
+- PT[long]  vs CM[long]      → 0.4742
+- OPT[fox]  vs INT8[fox]     → 0.9987 (compute-units only)
+- INT8[fox] vs INT8D512[fox] → 0.7881 (bucket prune)
+
+Quantization is innocent. Bucket pruning costs ~0.21 cosine. Compute
+placement costs ~0.20.
+
+### Trial 24 — PT-vs-CM with a real reference voice
+**Approach:** Use `FluidAudio/english_original.wav` (4.11 s real
+recording) as `ref_s` source for both PyTorch and CoreML pipelines,
+then ECAPA-cosine all three (REF, PT, CM).
+**Result:**
+- cos(REF, PT) = **0.2933**  ← PyTorch's own ceiling vs target voice
+- cos(REF, CM) = **0.1795**
+- cos(PT, CM)  = **0.2620**
+- log-mel cos(PT, CM) = **0.7889**
+
+**Diagnosis:** StyleTTS2's voice-clone fidelity is bounded by the
+model itself, not by CoreML conversion. PyTorch fp32 clones at cosine
+0.29 to its target — ECAPA's same-speaker threshold is ~0.3. The
+"robotic" complaint is the model architecture; CoreML adds ~0.11 on
+top of the architectural ceiling. There is no quantization or
+placement change that recovers the voice; it doesn't exist in the
+weights.
+
+### Trial 25 — Sweep around the architectural ceiling
+**Approach:** 10-config sweep — α/β style mixing, seed lottery,
+diffusion-step counts.
+**Result:**
+- Best speaker preservation: `alpha=0, beta=0` → cos(REF, ·) = 0.232.
+- Seed lottery: seeds {0, 1, 42} → {0.18, 0.26, 0.08}. The single best
+  seed wins more than any architectural knob.
+- Diffusion steps {3, 5, 8, 12}: monotone but ≤0.02 spread.
+
+**Conclusion:** Ship as-is. Style-mixing knobs and seed selection are
+post-hoc improvements that belong in the Swift caller, not in the
+conversion artifacts.
+
+---
+
+## Summary of key bugs
+
+| Bug                                       | Symptom                                   | Fix                                                           |
+|-------------------------------------------|-------------------------------------------|---------------------------------------------------------------|
+| BiLSTM zero-pad contamination             | Stage A cosine 0.9999 alone, 0.91 e2e     | Slice to `T_real` before calling text_predictor              |
+| Cumulative-duration rounding mismatch     | F0 drift across utterance                 | Match `floor` (PyTorch) — anchor last token at last mel frame |
+| Phase decorrelation in trace harness      | Sample cosine 1.0, mel cosine 0.85        | Lock single seeded RNG across e2e parity sweep                |
+| diffusion_step on ANE                     | Per-step 350 ms+ with ANE↔CPU fallback     | Pin `CPU_AND_GPU`                                             |
+| decoder on ANE                            | HiFi-GAN slower than CPU+GPU              | Pin `CPU_AND_GPU`                                             |
+| Naive `linear_quantize_weights`           | Buzzing on vowels, log-mel 0.86           | Add `weight_threshold=200_000`                                |
+| int8 on diffusion_step                    | Compounded denoiser noise, log-mel 0.91   | Don't quantize iterative stages                               |
+| int8 on decoder                           | Periodic artifacts on upsample stride     | Don't quantize transposed-conv stacks                         |
+| Cold-first-call ANE compile               | First RTFx 1.24×, then 4.32×              | Explicit warmup loop on app launch                            |
+| GE2E noise-floor on synthetic TTS         | False high-drift signal (0.84 looks bad)  | Use ECAPA-TDNN; threshold-aware                               |
+| `torchaudio.load` missing `torchcodec`    | `ModuleNotFoundError`                     | Use `soundfile` + manual resample                             |
+| "Robotic" voice quality complaint         | Audibly stiff prosody                     | Architectural — PyTorch fp32 ceiling cos(REF,PT)=0.29         |

--- a/models/tts/styletts2/pyproject.toml
+++ b/models/tts/styletts2/pyproject.toml
@@ -1,0 +1,35 @@
+[project]
+name = "styletts2-coreml"
+version = "0.1.0"
+description = "yl4579 StyleTTS2 → CoreML conversion (LibriTTS, HiFi-GAN)"
+requires-python = ">=3.10,<3.13"
+dependencies = [
+    # Pin <2.0: coremltools 8.3 trips on numpy>=2 in `np.issubdtype(end, np.integer)`
+    # for slice ops (Var dtype isn't a numpy scalar in numpy 2.x's stricter API).
+    "numpy>=1.24,<2.0",
+    "torch>=2.5.0",
+    "torchaudio>=2.5.0",
+    # Pin <9.0: coremltools 9.0 ships as a pure-python wheel without the
+    # libcoremlpython / libmilstoragepython native extensions, so save() fails
+    # with `BlobWriter not loaded`.
+    "coremltools>=8.0,<9.0",
+    "soundfile>=0.12.0",
+    "scipy>=1.5.0",
+    "huggingface_hub>=0.10",
+    "phonemizer>=3.2.0",
+    # Pin pre-5.0: the masking_utils refactor in 5.x breaks tracing through AlbertModel.
+    "transformers>=4.40,<5.0",
+    "einops>=0.7",
+    "einops-exts>=0.0.4",
+    "munch>=4.0",
+    "pyyaml>=6.0",
+]
+
+[tool.uv.sources]
+torch = [
+    { index = "pytorch-cpu" },
+]
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"

--- a/models/tts/styletts2/scripts/00_fetch_weights.py
+++ b/models/tts/styletts2/scripts/00_fetch_weights.py
@@ -1,0 +1,76 @@
+"""Fetch StyleTTS2-LibriTTS weights and strip them down to the inference modules.
+
+The upstream `.pth` is ~750 MB because it carries optimizer state, EMA copies,
+and discriminators (WavLM, MultiPeriod, MultiResSpec). For inference we only
+need: text_encoder, predictor, predictor_encoder, style_encoder, bert,
+bert_encoder, decoder, diffusion (sampler).
+
+Output: checkpoints/styletts2_libritts_inference.pt — a dict mapping module
+name → state_dict for only the modules listed above.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+from huggingface_hub import hf_hub_download
+
+REPO_ID = "yl4579/StyleTTS2-LibriTTS"
+CHECKPOINT_FILE = "Models/LibriTTS/epochs_2nd_00020.pth"
+INFERENCE_MODULES = (
+    "text_encoder",
+    "predictor",
+    "predictor_encoder",
+    "style_encoder",
+    "bert",
+    "bert_encoder",
+    "decoder",
+    "diffusion",
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path(__file__).resolve().parents[1] / "checkpoints" / "styletts2_libritts_inference.pt",
+    )
+    args = parser.parse_args()
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+
+    print(f"[00] downloading {REPO_ID}/{CHECKPOINT_FILE} …")
+    src = hf_hub_download(repo_id=REPO_ID, filename=CHECKPOINT_FILE)
+    print(f"[00] loading {src}")
+    raw = torch.load(src, map_location="cpu", weights_only=False)
+
+    # Upstream stores under either "net" or directly at top level depending on
+    # checkpoint vintage. Probe both.
+    state = raw.get("net", raw)
+    stripped: dict[str, dict] = {}
+    for name in INFERENCE_MODULES:
+        if name not in state:
+            print(f"[00]   ! module {name!r} missing from checkpoint")
+            continue
+        sd = state[name]
+        # If wrapped in EMA dict ({'params': ...}), unwrap.
+        if isinstance(sd, dict) and "params" in sd and "shadow_params" not in sd:
+            sd = sd["params"]
+        # Upstream trained with DataParallel; every key has a `module.` prefix.
+        # Demo notebook strips it before load_state_dict(..., strict=False).
+        sd = {k[len("module."):] if k.startswith("module.") else k: v for k, v in sd.items()}
+        stripped[name] = sd
+        n_params = sum(t.numel() for t in sd.values() if torch.is_tensor(t))
+        print(f"[00]   - {name}: {n_params/1e6:.2f}M params")
+
+    print(f"[00] writing {args.out}")
+    torch.save(stripped, args.out)
+    total = sum(t.numel() for sd in stripped.values() for t in sd.values() if torch.is_tensor(t))
+    print(f"[00] done. inference total: {total/1e6:.2f}M params")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/tts/styletts2/scripts/01_export_text_predictor.py
+++ b/models/tts/styletts2/scripts/01_export_text_predictor.py
@@ -1,0 +1,147 @@
+"""Export Package A: text encoder + PL-BERT + bert_encoder + duration predictor.
+
+Inputs:
+  tokens: (1, T_tok) int32, T_tok ∈ buckets
+  style:  (1, 128)   float32      (the `s` half of the predicted style)
+
+Outputs:
+  t_en:            (1, 512, T_tok)
+  d_en:            (1, 512, T_tok)
+  d:               (1, T_tok, 640)            (h + s)
+  pred_dur_log:    (1, T_tok, max_dur=50)     pre-sigmoid duration logits
+  fixed_embedding: (1, T_tok, 768)            for CFG uncond branch in Swift
+  bert_dur:        (1, T_tok, 768)            cond branch input
+
+Compute units: CPU + GPU (BiLSTM is not ANE-friendly).
+
+Bucketing: a single mlpackage with EnumeratedShapes on `tokens` compiles but
+mis-propagates symbolic shape: at runtime `d` collapses to (1, T, 512) instead
+of (1, T, 640), and `fixed_embedding` collapses to (1, 0, 0). Mirroring
+04_export_decoder.py / 02_export_diffusion_step.py, emit one fixed-shape
+mlpackage per token bucket: `styletts2_text_predictor_<T_tok>.mlpackage`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _styletts2_lib import (  # noqa: E402
+    COREML_DIR,
+    DEFAULT_CHECKPOINT,
+    LibriTTSConfig,
+    TextPredictorTraceable,
+    load_inference_modules,
+)
+
+DEFAULT_TOK_BUCKETS = (32, 64, 128, 256, 512)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--checkpoint", type=Path, default=DEFAULT_CHECKPOINT)
+    parser.add_argument(
+        "--out-dir", type=Path, default=COREML_DIR,
+        help="Directory; per-bucket mlpackages are saved as styletts2_text_predictor_<T_tok>.mlpackage.",
+    )
+    parser.add_argument("--buckets", type=int, nargs="+", default=list(DEFAULT_TOK_BUCKETS))
+    parser.add_argument("--trace-only", action="store_true", help="Run trace; skip CoreML conversion.")
+    parser.add_argument(
+        "--compute-units",
+        choices=["all", "cpu_and_gpu", "cpu_only"],
+        default="cpu_and_gpu",
+        help="BiLSTM rejects ANE placement; cpu_and_gpu is the default.",
+    )
+    args = parser.parse_args()
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    print("[01] loading inference modules …")
+    modules, cfg = load_inference_modules(args.checkpoint)
+
+    print("[01] building TextPredictorTraceable …")
+    wrapper = TextPredictorTraceable(modules).eval()
+
+    if args.trace_only:
+        largest = max(args.buckets)
+        example_tokens = torch.zeros(1, largest, dtype=torch.long)
+        example_style = torch.zeros(1, cfg.style_dim, dtype=torch.float32)
+        print(f"[01] sanity forward at T_tok={largest} …")
+        with torch.no_grad():
+            outs = wrapper(example_tokens, example_style)
+        for name, t in zip(
+            ("t_en", "d_en", "d", "pred_dur_log", "fixed_embedding", "bert_dur"), outs
+        ):
+            print(f"[01]   {name}: {tuple(t.shape)} {t.dtype}")
+        print("[01] tracing (largest bucket only) …")
+        with torch.no_grad():
+            torch.jit.trace(wrapper, (example_tokens, example_style), strict=False)
+        print("[01] --trace-only: skipping CoreML convert.")
+        return
+
+    import coremltools as ct  # local import — heavy
+
+    cu = {
+        "all": ct.ComputeUnit.ALL,
+        "cpu_and_gpu": ct.ComputeUnit.CPU_AND_GPU,
+        "cpu_only": ct.ComputeUnit.CPU_ONLY,
+    }[args.compute_units]
+
+    # See module docstring: EnumeratedShapes mis-propagates symbolic dims (d
+    # output collapses to 512-d, fixed_embedding collapses to (1,0,0)). Emit
+    # one fixed-shape mlpackage per token bucket; route at runtime.
+    for t_tok in sorted(args.buckets):
+        out_path = args.out_dir / f"styletts2_text_predictor_{t_tok}.mlpackage"
+        print(f"[01] === T_tok={t_tok}  →  {out_path.name} ===")
+
+        example_tokens = torch.zeros(1, t_tok, dtype=torch.long)
+        example_style = torch.zeros(1, cfg.style_dim, dtype=torch.float32)
+
+        with torch.no_grad():
+            outs = wrapper(example_tokens, example_style)
+        for name, t in zip(
+            ("t_en", "d_en", "d", "pred_dur_log", "fixed_embedding", "bert_dur"), outs
+        ):
+            print(f"[01]   sanity {name}: {tuple(t.shape)} {t.dtype}")
+
+        print("[01]   tracing …")
+        with torch.no_grad():
+            traced = torch.jit.trace(wrapper, (example_tokens, example_style), strict=False)
+
+        print(f"[01]   converting (compute_units={args.compute_units}) …", flush=True)
+        # skip_model_load avoids the post-convert MLModel instantiation which
+        # otherwise hangs Apple's anecompilerservice for several minutes per
+        # bucket. The mlpackage is saved correctly.
+        mlmodel = ct.convert(
+            traced,
+            inputs=[
+                ct.TensorType(name="tokens", shape=(1, t_tok), dtype=np.int32),
+                ct.TensorType(name="style", shape=(1, cfg.style_dim), dtype=np.float32),
+            ],
+            outputs=[
+                ct.TensorType(name="t_en"),
+                ct.TensorType(name="d_en"),
+                ct.TensorType(name="d"),
+                ct.TensorType(name="pred_dur_log"),
+                ct.TensorType(name="fixed_embedding"),
+                ct.TensorType(name="bert_dur"),
+            ],
+            minimum_deployment_target=ct.target.iOS17,
+            compute_units=cu,
+            convert_to="mlprogram",
+            skip_model_load=True,
+        )
+        mlmodel.short_description = (
+            f"StyleTTS2 text+predictor (LibriTTS HiFi-GAN) @ T_tok={t_tok}."
+        )
+        mlmodel.save(str(out_path))
+        print(f"[01]   saved → {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/tts/styletts2/scripts/02_export_diffusion_step.py
+++ b/models/tts/styletts2/scripts/02_export_diffusion_step.py
@@ -1,0 +1,153 @@
+"""Export Package B: a single ADPM2 / Karras denoising step of the style UNet.
+
+Sampler loop runs in Swift. CFG combination (cond + uncond) also in Swift —
+Swift calls this model twice with different `embedding` inputs.
+
+Inputs:
+  x_noisy:   (1, 1, 256)
+  sigma:     (1,)                  scalar noise level
+  embedding: (1, T_tok, 768)       bert_dur (cond) or fixed_embedding (uncond)
+  features:  (1, 256)              ref_s
+
+Output:
+  denoised:  (1, 1, 256)
+
+Compute units: CPU + GPU. Small UNet, ~5 calls per utterance.
+
+Bucketing: a single mlpackage with EnumeratedShapes on `embedding` compiles
+fine but fails to load on iOS17 mlprogram with
+  "tensor_buffer has known strides while the model has FlexibleShapeInfo.
+   Strides must be unknown on all dimensions." (CoreML err -14)
+Mirroring 04_export_decoder.py, we emit one fixed-shape mlpackage per token
+bucket: `styletts2_diffusion_step_<T_tok>.mlpackage`. Callers route by length.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _styletts2_lib import (  # noqa: E402
+    COREML_DIR,
+    DEFAULT_CHECKPOINT,
+    DiffusionDenoiseTraceable,
+    LibriTTSConfig,
+    load_inference_modules,
+)
+
+DEFAULT_TOK_BUCKETS = (32, 64, 128, 256, 512)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--checkpoint", type=Path, default=DEFAULT_CHECKPOINT)
+    parser.add_argument(
+        "--out-dir", type=Path, default=COREML_DIR,
+        help="Directory; per-bucket mlpackages are saved as styletts2_diffusion_step_<T_tok>.mlpackage.",
+    )
+    parser.add_argument("--buckets", type=int, nargs="+", default=list(DEFAULT_TOK_BUCKETS))
+    parser.add_argument("--trace-only", action="store_true")
+    parser.add_argument(
+        "--compute-units",
+        choices=["all", "cpu_and_gpu", "cpu_only"],
+        default="all",
+        help="Default 'all' targets ANE; fall back to cpu_and_gpu if placement fails.",
+    )
+    args = parser.parse_args()
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    print("[02] loading inference modules …")
+    modules, cfg = load_inference_modules(args.checkpoint)
+
+    print("[02] building DiffusionDenoiseTraceable …")
+    wrapper = DiffusionDenoiseTraceable(modules, cfg.diffusion_sigma_data).eval()
+
+    style_ch = cfg.style_dim * 2  # 256
+    bert_dim = modules["bert"].config.hidden_size  # 768
+
+    if args.trace_only:
+        largest = max(args.buckets)
+        example_x = torch.zeros(1, 1, style_ch, dtype=torch.float32)
+        example_sigma = torch.tensor([1.0], dtype=torch.float32)
+        example_embedding = torch.zeros(1, largest, bert_dim, dtype=torch.float32)
+        example_features = torch.zeros(1, style_ch, dtype=torch.float32)
+        print(f"[02] sanity forward at T_tok={largest} …")
+        with torch.no_grad():
+            out = wrapper(example_x, example_sigma, example_embedding, example_features)
+        print(f"[02]   denoised: {tuple(out.shape)} {out.dtype}")
+        print("[02] tracing (largest bucket only) …")
+        with torch.no_grad():
+            torch.jit.trace(
+                wrapper,
+                (example_x, example_sigma, example_embedding, example_features),
+                strict=False,
+            )
+        print("[02] --trace-only: skipping CoreML convert.")
+        return
+
+    import coremltools as ct
+
+    cu = {
+        "all": ct.ComputeUnit.ALL,
+        "cpu_and_gpu": ct.ComputeUnit.CPU_AND_GPU,
+        "cpu_only": ct.ComputeUnit.CPU_ONLY,
+    }[args.compute_units]
+
+    # See module docstring: EnumeratedShapes on `embedding` triggers the
+    # iOS17 mlprogram FlexibleShapeInfo strides bug at runtime. Emit one
+    # fixed-shape mlpackage per token bucket; route at runtime.
+    for t_tok in sorted(args.buckets):
+        out_path = args.out_dir / f"styletts2_diffusion_step_{t_tok}.mlpackage"
+        print(f"[02] === T_tok={t_tok}  →  {out_path.name} ===")
+
+        example_x = torch.zeros(1, 1, style_ch, dtype=torch.float32)
+        example_sigma = torch.tensor([1.0], dtype=torch.float32)
+        example_embedding = torch.zeros(1, t_tok, bert_dim, dtype=torch.float32)
+        example_features = torch.zeros(1, style_ch, dtype=torch.float32)
+
+        with torch.no_grad():
+            out = wrapper(example_x, example_sigma, example_embedding, example_features)
+        print(f"[02]   sanity denoised: {tuple(out.shape)} {out.dtype}")
+
+        print("[02]   tracing …")
+        with torch.no_grad():
+            traced = torch.jit.trace(
+                wrapper,
+                (example_x, example_sigma, example_embedding, example_features),
+                strict=False,
+            )
+
+        print(f"[02]   converting (compute_units={args.compute_units}) …", flush=True)
+        # skip_model_load avoids the post-convert MLModel instantiation which
+        # otherwise hangs Apple's anecompilerservice for several minutes per
+        # bucket. The mlpackage is saved correctly; first runtime load pays
+        # the compile cost once, then it's cached.
+        mlmodel = ct.convert(
+            traced,
+            inputs=[
+                ct.TensorType(name="x_noisy", shape=(1, 1, style_ch), dtype=np.float32),
+                ct.TensorType(name="sigma", shape=(1,), dtype=np.float32),
+                ct.TensorType(name="embedding", shape=(1, t_tok, bert_dim), dtype=np.float32),
+                ct.TensorType(name="features", shape=(1, style_ch), dtype=np.float32),
+            ],
+            outputs=[ct.TensorType(name="denoised")],
+            minimum_deployment_target=ct.target.iOS17,
+            compute_units=cu,
+            convert_to="mlprogram",
+            skip_model_load=True,
+        )
+        mlmodel.short_description = (
+            f"StyleTTS2 KDiffusion single denoise step (StyleTransformer1d) @ T_tok={t_tok}."
+        )
+        mlmodel.save(str(out_path))
+        print(f"[02]   saved → {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/tts/styletts2/scripts/03_export_f0n_energy.py
+++ b/models/tts/styletts2/scripts/03_export_f0n_energy.py
@@ -1,0 +1,99 @@
+"""Export Package C: predictor.F0Ntrain — F0 + energy prediction over mel time.
+
+Inputs:
+  en: (1, 640, T_mel)
+  s:  (1, 128)
+
+Outputs:
+  F0: (1, T_mel)
+  N:  (1, T_mel)
+
+Compute units: ANE-eligible (AdainResBlk1d stack + bidirectional LSTM with
+fixed seq dim). T_mel bucketed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _styletts2_lib import (  # noqa: E402
+    COREML_DIR,
+    DEFAULT_CHECKPOINT,
+    F0NEnergyTraceable,
+    LibriTTSConfig,
+    load_inference_modules,
+)
+
+DEFAULT_MEL_BUCKETS = (256, 512, 1024, 2048, 4096)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--checkpoint", type=Path, default=DEFAULT_CHECKPOINT)
+    parser.add_argument(
+        "--out", type=Path, default=COREML_DIR / "styletts2_f0n_energy.mlpackage"
+    )
+    parser.add_argument("--mel-buckets", type=int, nargs="+", default=list(DEFAULT_MEL_BUCKETS))
+    parser.add_argument("--trace-only", action="store_true")
+    args = parser.parse_args()
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+
+    print("[03] loading inference modules …")
+    modules, cfg = load_inference_modules(args.checkpoint)
+
+    print("[03] building F0NEnergyTraceable …")
+    wrapper = F0NEnergyTraceable(modules).eval()
+
+    # F0Ntrain.shared LSTM expects hidden_dim + style_dim (= 640) channels:
+    # upstream feeds it `d.transpose(-1,-2) @ alignment` where d is the
+    # DurationEncoder output (channel dim = h+s).
+    en_channels = cfg.hidden_dim + cfg.style_dim
+    largest = max(args.mel_buckets)
+    example_en = torch.zeros(1, en_channels, largest, dtype=torch.float32)
+    example_s = torch.zeros(1, cfg.style_dim, dtype=torch.float32)
+
+    print(f"[03] sanity forward at T_mel={largest} …")
+    with torch.no_grad():
+        F0, N = wrapper(example_en, example_s)
+    print(f"[03]   F0: {tuple(F0.shape)}  N: {tuple(N.shape)}")
+
+    print("[03] tracing …")
+    with torch.no_grad():
+        traced = torch.jit.trace(wrapper, (example_en, example_s), strict=False)
+
+    if args.trace_only:
+        print("[03] --trace-only: skipping CoreML convert.")
+        return
+
+    import coremltools as ct
+
+    print(f"[03] converting with mel buckets {args.mel_buckets} …")
+    en_enum = ct.EnumeratedShapes(
+        shapes=[(1, en_channels, b) for b in sorted(args.mel_buckets)],
+        default=(1, en_channels, largest),
+    )
+    mlmodel = ct.convert(
+        traced,
+        inputs=[
+            ct.TensorType(name="en", shape=en_enum, dtype=np.float32),
+            ct.TensorType(name="s", shape=(1, cfg.style_dim), dtype=np.float32),
+        ],
+        outputs=[ct.TensorType(name="F0"), ct.TensorType(name="N")],
+        minimum_deployment_target=ct.target.iOS17,
+        compute_units=ct.ComputeUnit.ALL,
+        convert_to="mlprogram",
+    )
+    mlmodel.short_description = "StyleTTS2 F0Ntrain (LibriTTS). ANE-eligible."
+    mlmodel.save(str(args.out))
+    print(f"[03] saved → {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/tts/styletts2/scripts/04_export_decoder.py
+++ b/models/tts/styletts2/scripts/04_export_decoder.py
@@ -1,0 +1,156 @@
+"""Export Package D: HiFi-GAN Decoder.
+
+Frame-rate convention (matches upstream demo):
+  T_mel here = asr / DurationEncoder frame rate (≈80 fps at 24 kHz × hop=300).
+  F0Ntrain emits F0/N at 2× that rate (its AdainResBlk1d stack upsamples ×2),
+  and `decoder.F0_conv` / `decoder.N_conv` downsample by 2 with their stride.
+
+Inputs:
+  asr:      (1, 512, T_mel)
+  F0_curve: (1, 2*T_mel)
+  N:        (1, 2*T_mel)
+  s:        (1, 128)            (the `ref` half of the predicted style)
+
+Outputs:
+  waveform: (1, 1, T_mel * 600) at 24 kHz
+            (decoder.decode's last AdainResBlk1d has upsample=True (×2),
+             then Generator upsamples by 300 = ∏[10,5,3,2])
+
+Compute units: ALL (ANE-eligible). Falls back to CPU/GPU if any
+ConvTranspose1d in `Generator` rejects ANE placement — verify post-export.
+
+Bucketing: CoreML mlprogram only allows one EnumeratedShapes input per model
+and disallows mixing EnumeratedShapes with RangeDim. The decoder has three
+variable-T inputs (asr, F0_curve, N), so a single multi-bucket mlpackage
+fails to compile at runtime. The script emits one fixed-shape mlpackage per
+bucket: `styletts2_decoder_<T_mel>.mlpackage`. Callers route by length.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _styletts2_lib import (  # noqa: E402
+    COREML_DIR,
+    DEFAULT_CHECKPOINT,
+    HifiGanDecoderTraceable,
+    LibriTTSConfig,
+    load_inference_modules,
+    register_coreml_op_shims,
+)
+
+register_coreml_op_shims()
+
+DEFAULT_MEL_BUCKETS = (256, 512, 1024, 2048, 4096)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--checkpoint", type=Path, default=DEFAULT_CHECKPOINT)
+    parser.add_argument(
+        "--out-dir", type=Path, default=COREML_DIR,
+        help="Directory; per-bucket mlpackages are saved as styletts2_decoder_<T_mel>.mlpackage.",
+    )
+    parser.add_argument("--mel-buckets", type=int, nargs="+", default=list(DEFAULT_MEL_BUCKETS))
+    parser.add_argument("--trace-only", action="store_true")
+    parser.add_argument(
+        "--compute-units",
+        choices=["all", "cpu_and_gpu", "cpu_only"],
+        default="all",
+        help="If post-export ANE placement check fails, re-run with cpu_and_gpu.",
+    )
+    args = parser.parse_args()
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    print("[04] loading inference modules …")
+    modules, cfg = load_inference_modules(args.checkpoint)
+
+    print("[04] building HifiGanDecoderTraceable …")
+    wrapper = HifiGanDecoderTraceable(modules["decoder"]).eval()
+
+    if args.trace_only:
+        largest = max(args.mel_buckets)
+        example_asr = torch.zeros(1, cfg.hidden_dim, largest, dtype=torch.float32)
+        example_F0 = torch.zeros(1, largest * 2, dtype=torch.float32)
+        example_N = torch.zeros(1, largest * 2, dtype=torch.float32)
+        example_s = torch.zeros(1, cfg.style_dim, dtype=torch.float32)
+        print(f"[04] sanity forward at T_mel={largest} …")
+        with torch.no_grad():
+            wav = wrapper(example_asr, example_F0, example_N, example_s)
+        expected = largest * 2 * cfg.hop_factor
+        print(f"[04]   waveform: {tuple(wav.shape)}  (expected last dim = {expected})")
+        print("[04] tracing (largest bucket only) …")
+        with torch.no_grad():
+            torch.jit.trace(
+                wrapper, (example_asr, example_F0, example_N, example_s), strict=False
+            )
+        print("[04] --trace-only: skipping CoreML convert.")
+        return
+
+    import coremltools as ct
+
+    cu = {
+        "all": ct.ComputeUnit.ALL,
+        "cpu_and_gpu": ct.ComputeUnit.CPU_AND_GPU,
+        "cpu_only": ct.ComputeUnit.CPU_ONLY,
+    }[args.compute_units]
+
+    # CoreML mlprogram allows only one EnumeratedShapes input per model and
+    # disallows mixing EnumeratedShapes with RangeDim. With three variable-T
+    # inputs (asr, F0, N) any combined-flexibility export fails to compile.
+    # Emit one fixed-shape mlpackage per bucket; routing happens at runtime.
+    for t_mel in sorted(args.mel_buckets):
+        out_path = args.out_dir / f"styletts2_decoder_{t_mel}.mlpackage"
+        print(f"[04] === T_mel={t_mel}  →  {out_path.name} ===")
+
+        example_asr = torch.zeros(1, cfg.hidden_dim, t_mel, dtype=torch.float32)
+        example_F0 = torch.zeros(1, t_mel * 2, dtype=torch.float32)
+        example_N = torch.zeros(1, t_mel * 2, dtype=torch.float32)
+        example_s = torch.zeros(1, cfg.style_dim, dtype=torch.float32)
+
+        with torch.no_grad():
+            wav = wrapper(example_asr, example_F0, example_N, example_s)
+        expected = t_mel * 2 * cfg.hop_factor
+        print(f"[04]   sanity waveform: {tuple(wav.shape)}  (expected last dim = {expected})")
+
+        print("[04]   tracing …")
+        with torch.no_grad():
+            traced = torch.jit.trace(
+                wrapper, (example_asr, example_F0, example_N, example_s), strict=False
+            )
+
+        print(f"[04]   converting (compute_units={args.compute_units}) …", flush=True)
+        # skip_model_load avoids the post-convert MLModel instantiation which
+        # otherwise hangs Apple's anecompilerservice for several minutes per
+        # bucket. The mlpackage is still saved correctly; first runtime load
+        # in the consumer pays the ANE compile cost once, then it's cached.
+        mlmodel = ct.convert(
+            traced,
+            inputs=[
+                ct.TensorType(name="asr", shape=(1, cfg.hidden_dim, t_mel), dtype=np.float32),
+                ct.TensorType(name="F0_curve", shape=(1, 2 * t_mel), dtype=np.float32),
+                ct.TensorType(name="N", shape=(1, 2 * t_mel), dtype=np.float32),
+                ct.TensorType(name="s", shape=(1, cfg.style_dim), dtype=np.float32),
+            ],
+            outputs=[ct.TensorType(name="waveform")],
+            minimum_deployment_target=ct.target.iOS17,
+            compute_units=cu,
+            convert_to="mlprogram",
+            skip_model_load=True,
+        )
+        mlmodel.short_description = (
+            f"StyleTTS2 HiFi-GAN decoder (LibriTTS) @ T_mel={t_mel}. 24 kHz, hop=300."
+        )
+        mlmodel.save(str(out_path))
+        print(f"[04]   saved → {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/tts/styletts2/scripts/04_export_decoder.py
+++ b/models/tts/styletts2/scripts/04_export_decoder.py
@@ -41,6 +41,7 @@ from _styletts2_lib import (  # noqa: E402
     DEFAULT_CHECKPOINT,
     HifiGanDecoderTraceable,
     LibriTTSConfig,
+    install_sinegen_v2_constfold_fix,
     load_inference_modules,
     register_coreml_op_shims,
 )
@@ -77,6 +78,8 @@ def main() -> None:
 
     if args.trace_only:
         largest = max(args.mel_buckets)
+        print(f"[04] installing SineGen v2 constfold fix for T_mel={largest} …")
+        install_sinegen_v2_constfold_fix(largest)
         example_asr = torch.zeros(1, cfg.hidden_dim, largest, dtype=torch.float32)
         example_F0 = torch.zeros(1, largest * 2, dtype=torch.float32)
         example_N = torch.zeros(1, largest * 2, dtype=torch.float32)
@@ -109,6 +112,12 @@ def main() -> None:
     for t_mel in sorted(args.mel_buckets):
         out_path = args.out_dir / f"styletts2_decoder_{t_mel}.mlpackage"
         print(f"[04] === T_mel={t_mel}  →  {out_path.name} ===")
+
+        # Re-bind the SineGen monkey patch with the constant `fracs` index for
+        # this bucket's T_audio. Must happen before trace; idempotent across
+        # calls. See PHASE6_FP16_DECODER.md for the bug it fixes.
+        print(f"[04]   installing SineGen v2 constfold fix for T_mel={t_mel} …")
+        install_sinegen_v2_constfold_fix(t_mel)
 
         example_asr = torch.zeros(1, cfg.hidden_dim, t_mel, dtype=torch.float32)
         example_F0 = torch.zeros(1, t_mel * 2, dtype=torch.float32)

--- a/models/tts/styletts2/scripts/04_export_decoder.py
+++ b/models/tts/styletts2/scripts/04_export_decoder.py
@@ -140,6 +140,12 @@ def main() -> None:
         # otherwise hangs Apple's anecompilerservice for several minutes per
         # bucket. The mlpackage is still saved correctly; first runtime load
         # in the consumer pays the ANE compile cost once, then it's cached.
+        # compute_precision=FLOAT32 is required: the SineGen harmonic source
+        # accumulates phase via cumsum × 2π × 300, reaching magnitudes ~4000
+        # mid-frame. fp16 precision (~4 at that magnitude) is much larger
+        # than the per-sample phase increment (~0.05 rad), which scrambles
+        # the sin output and produces robotic audio. See PHASE6_FP16_DECODER.md
+        # for the full diagnosis and two viable fp16-stabilization sketches.
         mlmodel = ct.convert(
             traced,
             inputs=[
@@ -151,6 +157,7 @@ def main() -> None:
             outputs=[ct.TensorType(name="waveform")],
             minimum_deployment_target=ct.target.iOS17,
             compute_units=cu,
+            compute_precision=ct.precision.FLOAT32,
             convert_to="mlprogram",
             skip_model_load=True,
         )

--- a/models/tts/styletts2/scripts/99_parity_check.py
+++ b/models/tts/styletts2/scripts/99_parity_check.py
@@ -1,0 +1,496 @@
+"""End-to-end StyleTTS2 inference + parity vs PyTorch reference.
+
+Pipeline (mirrors `Demo/Inference_LibriTTS.ipynb`):
+  1. Phonemize text → tokens.
+  2. ref_s ← style_encoder + predictor_encoder on reference WAV (24 kHz mel).
+  3. text_predictor (Package A): tokens, ref_s.first_half → t_en, d_en, d, dur, fixed_emb.
+  4. Diffusion sampler (5 ADPM2 steps) using diffusion_step (Package B), CFG with
+     embedding_scale=1 collapses to a single forward per step.
+  5. Build alignment from rounded predicted durations.
+  6. en = d.transpose @ alignment;  asr = t_en @ alignment;
+     hifigan-shift both right by 1 frame (matches notebook).
+  7. f0n_energy (Package C): en, s → F0, N (at 2× T_mel).
+  8. decoder bucket (Package D): asr, F0, N, ref → waveform.
+
+For each stage we run both PyTorch and CoreML and report
+  cosine_sim, max_abs_delta
+side-by-side. Both pipelines write a WAV; outputs land in --out-dir.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+import torch
+import torch.nn.functional as F
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _styletts2_lib import (  # noqa: E402
+    COREML_DIR,
+    DEFAULT_CHECKPOINT,
+    LibriTTSConfig,
+    load_inference_modules,
+    register_coreml_op_shims,
+)
+
+register_coreml_op_shims()
+
+DEFAULT_TEXT = (
+    "StyleTTS 2 is a text to speech model that leverages style diffusion and "
+    "adversarial training with large speech language models to achieve human "
+    "level text to speech synthesis."
+)
+
+TOKEN_BUCKETS = (32, 64, 128, 256, 512)
+MEL_BUCKETS = (256, 512, 1024, 2048, 4096)
+
+
+def cos_sim(a: np.ndarray, b: np.ndarray) -> float:
+    a = a.reshape(-1).astype(np.float64)
+    b = b.reshape(-1).astype(np.float64)
+    n = np.linalg.norm(a) * np.linalg.norm(b)
+    if n == 0:
+        return float("nan")
+    return float(a @ b / n)
+
+
+def report(name: str, ref: np.ndarray, hyp: np.ndarray) -> None:
+    if ref.shape != hyp.shape:
+        print(f"  {name}: SHAPE MISMATCH ref={ref.shape} hyp={hyp.shape}")
+        return
+    print(
+        f"  {name}: cos={cos_sim(ref, hyp):.6f}  "
+        f"max|Δ|={np.max(np.abs(ref - hyp)):.4e}  "
+        f"shape={tuple(ref.shape)}"
+    )
+
+
+def pick_bucket(n: int, buckets) -> int:
+    for b in buckets:
+        if n <= b:
+            return b
+    raise ValueError(f"value {n} exceeds largest bucket {buckets[-1]}")
+
+
+def phonemize_to_tokens(text: str):
+    """Mirror notebook cell 16: espeak phonemize → word_tokenize → TextCleaner."""
+    import phonemizer
+    from nltk.tokenize import word_tokenize
+    from text_utils import TextCleaner  # vendor/StyleTTS2
+
+    backend = phonemizer.backend.EspeakBackend(
+        language="en-us", preserve_punctuation=True, with_stress=True
+    )
+    ps = backend.phonemize([text.strip()])
+    ps = " ".join(word_tokenize(ps[0]))
+    cleaner = TextCleaner()
+    tokens = cleaner(ps)
+    tokens.insert(0, 0)
+    return torch.LongTensor(tokens).unsqueeze(0)  # (1, T_tok)
+
+
+def compute_ref_s(modules, wav_path: Path) -> torch.Tensor:
+    """Mirror notebook `compute_style`."""
+    import librosa
+    import torchaudio
+
+    to_mel = torchaudio.transforms.MelSpectrogram(
+        n_mels=80, n_fft=2048, win_length=1200, hop_length=300
+    )
+    mean, std = -4.0, 4.0
+
+    wave, sr = librosa.load(str(wav_path), sr=24000)
+    audio, _ = librosa.effects.trim(wave, top_db=30)
+    if sr != 24000:
+        audio = librosa.resample(audio, orig_sr=sr, target_sr=24000)
+    wav_t = torch.from_numpy(audio).float()
+    mel = to_mel(wav_t)
+    mel = (torch.log(1e-5 + mel.unsqueeze(0)) - mean) / std  # (1, 80, T)
+
+    with torch.no_grad():
+        ref_s = modules["style_encoder"](mel.unsqueeze(1))         # (1, 128)
+        ref_p = modules["predictor_encoder"](mel.unsqueeze(1))     # (1, 128)
+    return torch.cat([ref_s, ref_p], dim=1)                         # (1, 256)
+
+
+# --- PyTorch reference --------------------------------------------------------
+
+
+@torch.no_grad()
+def pytorch_inference(modules, cfg: LibriTTSConfig, tokens: torch.Tensor,
+                       ref_s: torch.Tensor, *, alpha=0.3, beta=0.7,
+                       diffusion_steps=5, embedding_scale=1, seed=0):
+    """Mirror notebook `inference()` on CPU. Returns dict of intermediates + wav."""
+    from Modules.diffusion.sampler import (
+        ADPM2Sampler,
+        DiffusionSampler,
+        KarrasSchedule,
+    )
+
+    torch.manual_seed(seed)
+    device = "cpu"
+    text_encoder = modules["text_encoder"]
+    bert = modules["bert"]
+    bert_encoder = modules["bert_encoder"]
+    predictor = modules["predictor"]
+    decoder = modules["decoder"]
+    diffusion = modules["diffusion"]
+
+    T_tok = tokens.shape[-1]
+    input_lengths = torch.LongTensor([T_tok])
+    text_mask = torch.zeros(1, T_tok, dtype=torch.bool)  # all valid
+
+    t_en = text_encoder(tokens, input_lengths, text_mask)              # (1, h, T_tok)
+    bert_dur = bert(tokens, attention_mask=(~text_mask).int())          # (1, T_tok, bert)
+    d_en = bert_encoder(bert_dur).transpose(-1, -2)                     # (1, h, T_tok)
+
+    sampler = DiffusionSampler(
+        diffusion.diffusion,
+        sampler=ADPM2Sampler(),
+        sigma_schedule=KarrasSchedule(sigma_min=0.0001, sigma_max=3.0, rho=9.0),
+        clamp=False,
+    )
+    noise = torch.randn(1, 1, 256, device=device)
+    s_pred = sampler(
+        noise=noise,
+        embedding=bert_dur,
+        embedding_scale=embedding_scale,
+        features=ref_s,
+        num_steps=diffusion_steps,
+    ).squeeze(1)  # (1, 256)
+
+    s = s_pred[:, 128:]
+    ref = s_pred[:, :128]
+    ref = alpha * ref + (1 - alpha) * ref_s[:, :128]
+    s = beta * s + (1 - beta) * ref_s[:, 128:]
+
+    d = predictor.text_encoder(d_en, s, input_lengths, text_mask)       # (1, T, h+s)
+    x, _ = predictor.lstm(d)
+    duration = predictor.duration_proj(x)
+    duration = torch.sigmoid(duration).sum(dim=-1)
+    pred_dur = torch.round(duration.squeeze()).clamp(min=1).long()
+
+    T_total = int(pred_dur.sum().item())
+    aln = torch.zeros(T_tok, T_total)
+    c = 0
+    for i in range(T_tok):
+        n = int(pred_dur[i].item())
+        aln[i, c:c + n] = 1.0
+        c += n
+    aln = aln.unsqueeze(0)                                              # (1, T_tok, T_mel)
+
+    en = d.transpose(-1, -2) @ aln                                      # (1, h+s, T_mel)
+    asr = t_en @ aln                                                    # (1, h, T_mel)
+    # hifigan shift-right by 1 frame
+    en_shift = torch.zeros_like(en)
+    en_shift[:, :, 0] = en[:, :, 0]
+    en_shift[:, :, 1:] = en[:, :, :-1]
+    asr_shift = torch.zeros_like(asr)
+    asr_shift[:, :, 0] = asr[:, :, 0]
+    asr_shift[:, :, 1:] = asr[:, :, :-1]
+    en, asr = en_shift, asr_shift
+
+    F0_pred, N_pred = predictor.F0Ntrain(en, s)                         # (1, 2*T_mel)
+
+    out = decoder(asr, F0_pred, N_pred, ref.squeeze().unsqueeze(0))     # (1, 1, T_mel*600)
+    wav = out.squeeze().cpu().numpy()
+    if wav.shape[-1] > 50:
+        wav = wav[..., :-50]
+    return {
+        "t_en": t_en.numpy(),
+        "d_en": d_en.numpy(),
+        "d": d.numpy(),
+        "pred_dur": pred_dur.numpy(),
+        "s": s.numpy(),
+        "ref": ref.numpy(),
+        "asr": asr.numpy(),
+        "en": en.numpy(),
+        "F0": F0_pred.numpy(),
+        "N": N_pred.numpy(),
+        "wav": wav,
+        "T_tok": T_tok,
+        "T_mel": T_total,
+        "bert_dur": bert_dur.numpy(),
+        "fixed_emb": diffusion.unet.fixed_embedding(bert_dur).numpy(),
+        "noise": noise.numpy(),
+    }
+
+
+# --- CoreML side --------------------------------------------------------------
+
+
+def coreml_inference(coreml_dir: Path, ref, cfg: LibriTTSConfig):
+    """Run each stage through CoreML using PyTorch intermediates as input.
+
+    Note: this does NOT re-run the diffusion sampler in CoreML (the Python
+    sampler loop is what we ship; we just need the per-step package to match
+    PyTorch numerically). For style we reuse the PyTorch-sampled `s_pred`.
+    """
+    import coremltools as ct
+
+    out = {}
+    print("[parity] loading CoreML packages …")
+    tp = ct.models.MLModel(str(coreml_dir / "styletts2_text_predictor.mlpackage"))
+    ds = ct.models.MLModel(str(coreml_dir / "styletts2_diffusion_step.mlpackage"))
+    fn = ct.models.MLModel(str(coreml_dir / "styletts2_f0n_energy.mlpackage"))
+
+    # === Stage A: text_predictor ===
+    T_tok = ref["T_tok"]
+    tok_bucket = pick_bucket(T_tok, TOKEN_BUCKETS)
+    tokens_pad = np.zeros((1, tok_bucket), dtype=np.int32)
+    # we stored tokens via the input torch tensor — recompute from t_en presence
+    # (we don't have raw tokens here; receive separately in driver below)
+    out["_tok_bucket"] = tok_bucket
+    out["_text_predictor"] = tp
+    out["_diffusion_step"] = ds
+    out["_f0n_energy"] = fn
+    return out
+
+
+def run_text_predictor(tp, tokens: torch.Tensor, ref_s: torch.Tensor, tok_bucket: int):
+    T_tok = tokens.shape[-1]
+    tokens_pad = np.zeros((1, tok_bucket), dtype=np.int32)
+    tokens_pad[0, :T_tok] = tokens.numpy().astype(np.int32)[0]
+    style_half = ref_s[:, :128].numpy().astype(np.float32)
+    feed = {"tokens": tokens_pad, "style": style_half}
+    pred = tp.predict(feed)
+    return pred  # dict of arrays at full bucket length
+
+
+def run_diffusion_step(ds, x_noisy: np.ndarray, sigma: float, embedding: np.ndarray,
+                       features: np.ndarray):
+    feed = {
+        "x_noisy": x_noisy.astype(np.float32),
+        "sigma": np.array([sigma], dtype=np.float32),
+        "embedding": embedding.astype(np.float32),
+        "features": features.astype(np.float32),
+    }
+    return ds.predict(feed)
+
+
+def run_f0n_energy(fn, en: np.ndarray, s: np.ndarray, mel_bucket: int):
+    en_pad = np.zeros((1, en.shape[1], mel_bucket), dtype=np.float32)
+    T = en.shape[2]
+    en_pad[:, :, :T] = en
+    feed = {"en": en_pad, "s": s.astype(np.float32)}
+    pred = fn.predict(feed)
+    return pred  # F0/N at (1, 2*mel_bucket)
+
+
+def run_decoder(coreml_dir: Path, asr: np.ndarray, F0: np.ndarray, N: np.ndarray,
+                ref: np.ndarray, mel_bucket: int):
+    import coremltools as ct
+    pkg = coreml_dir / f"styletts2_decoder_{mel_bucket}.mlpackage"
+    print(f"[parity] loading {pkg.name} …")
+    decoder = ct.models.MLModel(str(pkg))
+
+    asr_pad = np.zeros((1, asr.shape[1], mel_bucket), dtype=np.float32)
+    asr_pad[:, :, :asr.shape[2]] = asr
+    F0_pad = np.zeros((1, 2 * mel_bucket), dtype=np.float32)
+    F0_pad[:, :F0.shape[1]] = F0
+    N_pad = np.zeros((1, 2 * mel_bucket), dtype=np.float32)
+    N_pad[:, :N.shape[1]] = N
+    feed = {
+        "asr": asr_pad,
+        "F0_curve": F0_pad,
+        "N": N_pad,
+        "s": ref.astype(np.float32),
+    }
+    return decoder.predict(feed)
+
+
+# --- Diffusion sampler reimplemented over the CoreML step ---------------------
+#
+# Mirrors `Modules.diffusion.sampler.{KarrasSchedule, ADPM2Sampler}` paired with
+# `KDiffusion.denoise_fn` (which is what we wrapped as Package B). With
+# embedding_scale=1, CFG collapses to a single forward → exactly one denoise
+# call per step, matching the wrapper.
+
+
+def karras_sigmas(num_steps: int, sigma_min=0.0001, sigma_max=3.0, rho=9.0):
+    rho_inv = 1.0 / rho
+    ramp = np.linspace(0, 1, num_steps).astype(np.float64)
+    min_inv = sigma_min ** rho_inv
+    max_inv = sigma_max ** rho_inv
+    sigmas = (max_inv + ramp * (min_inv - max_inv)) ** rho
+    return np.concatenate([sigmas, [0.0]]).astype(np.float32)
+
+
+def adpm2_sample_coreml(ds, noise: np.ndarray, sigmas: np.ndarray,
+                        embedding: np.ndarray, features: np.ndarray):
+    """ADPM2 sampler over the CoreML denoise step. embedding_scale=1."""
+    x = noise.astype(np.float32) * float(sigmas[0])
+    for i in range(len(sigmas) - 1):
+        s, s_next = float(sigmas[i]), float(sigmas[i + 1])
+        # midpoint sigma per ADPM2: geometric mid in log space
+        if s_next == 0.0:
+            denoised = run_diffusion_step(ds, x, s, embedding, features)["denoised"]
+            d = (x - denoised) / s
+            x = x + d * (s_next - s)
+            continue
+        s_mid = float(np.exp((np.log(s) + np.log(s_next)) / 2))
+        denoised = run_diffusion_step(ds, x, s, embedding, features)["denoised"]
+        d = (x - denoised) / s
+        # half-step Euler to midpoint
+        x_mid = x + d * (s_mid - s)
+        denoised_mid = run_diffusion_step(ds, x_mid, s_mid, embedding, features)["denoised"]
+        d_mid = (x_mid - denoised_mid) / s_mid
+        x = x + d_mid * (s_next - s)
+    return x  # (1, 1, 256)
+
+
+# --- Main ---------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--text", default=DEFAULT_TEXT)
+    parser.add_argument("--reference-wav", type=Path, required=True,
+                        help="WAV used to extract ref_s (≥4 s, 24 kHz preferred).")
+    parser.add_argument("--checkpoint", type=Path, default=DEFAULT_CHECKPOINT)
+    parser.add_argument("--coreml-dir", type=Path, default=COREML_DIR)
+    parser.add_argument("--out-dir", type=Path, default=Path("/tmp/styletts2-parity"))
+    parser.add_argument("--diffusion-steps", type=int, default=5)
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    print("[parity] loading PyTorch modules …")
+    modules, cfg = load_inference_modules(args.checkpoint)
+
+    print(f"[parity] computing ref_s from {args.reference_wav}")
+    ref_s = compute_ref_s(modules, args.reference_wav)
+    print(f"[parity]   ref_s shape={tuple(ref_s.shape)}")
+
+    print("[parity] phonemizing …")
+    tokens = phonemize_to_tokens(args.text)
+    T_tok = tokens.shape[-1]
+    print(f"[parity]   T_tok={T_tok}")
+    tok_bucket = pick_bucket(T_tok, TOKEN_BUCKETS)
+    print(f"[parity]   token bucket={tok_bucket}")
+
+    print("[parity] running PyTorch reference …")
+    t0 = time.time()
+    ref = pytorch_inference(
+        modules, cfg, tokens, ref_s,
+        diffusion_steps=args.diffusion_steps, seed=args.seed,
+    )
+    pt_time = time.time() - t0
+    T_mel = ref["T_mel"]
+    mel_bucket = pick_bucket(T_mel, MEL_BUCKETS)
+    print(f"[parity]   PyTorch done in {pt_time:.2f}s  T_mel={T_mel}  bucket={mel_bucket}")
+
+    pt_wav_path = args.out_dir / "pytorch.wav"
+    sf.write(pt_wav_path, ref["wav"], 24000)
+    print(f"[parity]   wrote {pt_wav_path}  ({len(ref['wav']) / 24000:.2f}s)")
+
+    # === CoreML stages (each is best-effort; failures are reported, not fatal) ===
+    import coremltools as ct
+
+    def try_load(name: str):
+        try:
+            return ct.models.MLModel(str(args.coreml_dir / name))
+        except Exception as e:  # noqa: BLE001
+            print(f"[parity] FAILED to load {name}: {e}")
+            return None
+
+    print("[parity] loading CoreML packages …")
+    # text_predictor and diffusion_step are now per-bucket (T_tok). Fall back
+    # to the legacy single-file names if per-bucket files aren't present.
+    tp_per_bucket = f"styletts2_text_predictor_{tok_bucket}.mlpackage"
+    tp = try_load(tp_per_bucket) or try_load("styletts2_text_predictor.mlpackage")
+    ds_per_bucket = f"styletts2_diffusion_step_{tok_bucket}.mlpackage"
+    ds = try_load(ds_per_bucket) or try_load("styletts2_diffusion_step.mlpackage")
+    fn = try_load("styletts2_f0n_energy.mlpackage")
+
+    # --- Stage A: text_predictor ---
+    if tp is not None:
+        print(f"[parity] === Stage A: text_predictor (bucket={tok_bucket}) ===")
+        try:
+            t0 = time.time()
+            A = run_text_predictor(tp, tokens, ref_s, tok_bucket)
+            print(f"[parity]   coreml: {time.time() - t0:.2f}s")
+            for key, ref_arr, slicer in [
+                ("t_en", ref["t_en"], lambda a: a[..., :T_tok]),
+                ("d_en", ref["d_en"], lambda a: a[..., :T_tok]),
+                ("d   ", ref["d"], lambda a: a[:, :T_tok, :]),
+                ("fixed_emb", ref["fixed_emb"][:, :T_tok, :],
+                 lambda a: a[:, :T_tok, :]),
+            ]:
+                k = key.strip()
+                if k not in A and k != "fixed_emb":
+                    print(f"  {key}: missing from CoreML output (keys={list(A)})")
+                    continue
+                pred = A.get(k if k != "fixed_emb" else "fixed_embedding")
+                if pred is None:
+                    print(f"  {key}: missing")
+                    continue
+                report(key, ref_arr, slicer(pred))
+        except Exception as e:  # noqa: BLE001
+            print(f"[parity] Stage A failed: {e}")
+
+    # --- Stage B: diffusion sampler over CoreML step ---
+    if ds is not None:
+        print(f"[parity] === Stage B: diffusion ({args.diffusion_steps} steps) ===")
+        try:
+            sigmas = karras_sigmas(args.diffusion_steps)
+            # per-bucket diffusion_step needs embedding padded to tok_bucket.
+            bert_dur = ref["bert_dur"]
+            bert_dim = bert_dur.shape[-1]
+            embedding = np.zeros((1, tok_bucket, bert_dim), dtype=np.float32)
+            embedding[:, :T_tok, :] = bert_dur
+            features = ref_s.numpy().astype(np.float32)
+            t0 = time.time()
+            s_pred_coreml = adpm2_sample_coreml(
+                ds, ref["noise"], sigmas, embedding, features
+            )
+            print(f"[parity]   coreml: {time.time() - t0:.2f}s")
+            s_pred_coreml = s_pred_coreml.squeeze(1)
+            pt_s_pred = np.concatenate([ref["ref"], ref["s"]], axis=1)
+            print(f"  s_pred_coreml:  mean={s_pred_coreml.mean():.4f} std={s_pred_coreml.std():.4f}")
+            print(f"  s_pred_pytorch: mean={pt_s_pred.mean():.4f} std={pt_s_pred.std():.4f}")
+        except Exception as e:  # noqa: BLE001
+            print(f"[parity] Stage B failed: {e}")
+
+    # --- Stage C: F0Ntrain ---
+    if fn is not None:
+        print(f"[parity] === Stage C: f0n_energy (bucket={mel_bucket}) ===")
+        try:
+            t0 = time.time()
+            C = run_f0n_energy(fn, ref["en"], ref["s"], mel_bucket)
+            print(f"[parity]   coreml: {time.time() - t0:.2f}s")
+            coreml_F0 = C["F0"][:, :2 * T_mel]
+            coreml_N = C["N"][:, :2 * T_mel]
+            report("F0", ref["F0"], coreml_F0)
+            report("N ", ref["N"], coreml_N)
+        except Exception as e:  # noqa: BLE001
+            print(f"[parity] Stage C failed: {e}")
+
+    # --- Stage D: decoder bucket ---
+    print(f"[parity] === Stage D: decoder (bucket={mel_bucket}) ===")
+    try:
+        t0 = time.time()
+        D = run_decoder(args.coreml_dir, ref["asr"], ref["F0"], ref["N"],
+                        ref["ref"], mel_bucket)
+        print(f"[parity]   coreml: {time.time() - t0:.2f}s")
+        coreml_wav = D["waveform"].squeeze()[: T_mel * 600]
+        if coreml_wav.shape[-1] > 50:
+            coreml_wav = coreml_wav[..., :-50]
+        report("waveform", ref["wav"], coreml_wav)
+        cm_wav_path = args.out_dir / "coreml.wav"
+        sf.write(cm_wav_path, coreml_wav, 24000)
+        print(f"[parity]   wrote {cm_wav_path}  ({len(coreml_wav) / 24000:.2f}s)")
+    except Exception as e:  # noqa: BLE001
+        print(f"[parity] Stage D failed: {e}")
+
+    print("[parity] done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/tts/styletts2/scripts/99_parity_check.py
+++ b/models/tts/styletts2/scripts/99_parity_check.py
@@ -208,6 +208,10 @@ def pytorch_inference(modules, cfg: LibriTTSConfig, tokens: torch.Tensor,
         "pred_dur": pred_dur.numpy(),
         "s": s.numpy(),
         "ref": ref.numpy(),
+        # Raw ADPM2 sampler output before alpha/beta blending. Used by Stage B
+        # parity to compare CoreML sampler output against the same quantity
+        # in PyTorch (rather than against the post-blend `s` / `ref`).
+        "s_pred_raw": s_pred.numpy(),
         "asr": asr.numpy(),
         "en": en.numpy(),
         "F0": F0_pred.numpy(),
@@ -452,7 +456,11 @@ def main() -> None:
             )
             print(f"[parity]   coreml: {time.time() - t0:.2f}s")
             s_pred_coreml = s_pred_coreml.squeeze(1)
-            pt_s_pred = np.concatenate([ref["ref"], ref["s"]], axis=1)
+            # Compare raw sampler outputs only (pre-blend). The blended
+            # `s` / `ref` mix in the reference style and would conflate
+            # sampler parity with blending arithmetic.
+            pt_s_pred = ref["s_pred_raw"]
+            report("s_pred", pt_s_pred, s_pred_coreml)
             print(f"  s_pred_coreml:  mean={s_pred_coreml.mean():.4f} std={s_pred_coreml.std():.4f}")
             print(f"  s_pred_pytorch: mean={pt_s_pred.mean():.4f} std={pt_s_pred.std():.4f}")
         except Exception as e:  # noqa: BLE001

--- a/models/tts/styletts2/scripts/99b_e2e_coreml.py
+++ b/models/tts/styletts2/scripts/99b_e2e_coreml.py
@@ -1,0 +1,285 @@
+"""End-to-end StyleTTS2 inference using ONLY CoreML packages for the
+hot path. Times each stage and the full wall, computes RTFx.
+
+PyTorch is still used for:
+  - phonemizer (espeak, no CoreML equivalent needed)
+  - ref_s extraction (style_encoder/predictor_encoder — small CNN heads,
+    not on the hot path; could be exported but currently aren't)
+
+Everything downstream of `bert_dur` and `style` (text_predictor, diffusion,
+f0n_energy, decoder) runs through CoreML mlpackages.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _styletts2_lib import (  # noqa: E402
+    COREML_DIR,
+    DEFAULT_CHECKPOINT,
+    LibriTTSConfig,
+    load_inference_modules,
+    register_coreml_op_shims,
+)
+
+register_coreml_op_shims()
+
+DEFAULT_TEXT = "The quick brown fox jumps over the lazy dog."
+
+TOKEN_BUCKETS = (32, 64, 128, 256, 512)
+MEL_BUCKETS = (256, 512, 1024, 2048, 4096)
+
+
+def pick_bucket(n, buckets):
+    for b in buckets:
+        if n <= b:
+            return b
+    raise ValueError(f"value {n} exceeds largest bucket {buckets[-1]}")
+
+
+def phonemize(text):
+    import phonemizer
+    from nltk.tokenize import word_tokenize
+    from text_utils import TextCleaner
+
+    backend = phonemizer.backend.EspeakBackend(
+        language="en-us", preserve_punctuation=True, with_stress=True
+    )
+    ps = backend.phonemize([text.strip()])
+    ps = " ".join(word_tokenize(ps[0]))
+    cleaner = TextCleaner()
+    tokens = cleaner(ps)
+    tokens.insert(0, 0)
+    return torch.LongTensor(tokens).unsqueeze(0)
+
+
+def compute_ref_s(modules, wav_path):
+    import librosa
+    import torchaudio
+
+    to_mel = torchaudio.transforms.MelSpectrogram(
+        n_mels=80, n_fft=2048, win_length=1200, hop_length=300
+    )
+    mean, std = -4.0, 4.0
+    wave, sr = librosa.load(str(wav_path), sr=24000)
+    audio, _ = librosa.effects.trim(wave, top_db=30)
+    wav_t = torch.from_numpy(audio).float()
+    mel = to_mel(wav_t)
+    mel = (torch.log(1e-5 + mel.unsqueeze(0)) - mean) / std
+
+    with torch.no_grad():
+        ref_s = modules["style_encoder"](mel.unsqueeze(1))
+        ref_p = modules["predictor_encoder"](mel.unsqueeze(1))
+    return torch.cat([ref_s, ref_p], dim=1)
+
+
+def karras_sigmas(num_steps, sigma_min=0.0001, sigma_max=3.0, rho=9.0):
+    rho_inv = 1.0 / rho
+    ramp = np.linspace(0, 1, num_steps).astype(np.float64)
+    min_inv = sigma_min ** rho_inv
+    max_inv = sigma_max ** rho_inv
+    sigmas = (max_inv + ramp * (min_inv - max_inv)) ** rho
+    return np.concatenate([sigmas, [0.0]]).astype(np.float32)
+
+
+def adpm2_sample(ds_predict, noise, sigmas, embedding, features):
+    """ADPM2 sampler over the diffusion_step model. embedding_scale=1."""
+    x = noise.astype(np.float32) * float(sigmas[0])
+    for i in range(len(sigmas) - 1):
+        s, s_next = float(sigmas[i]), float(sigmas[i + 1])
+        if s_next == 0.0:
+            denoised = ds_predict(x, s, embedding, features)
+            d = (x - denoised) / s
+            x = x + d * (s_next - s)
+            continue
+        s_mid = float(np.exp((np.log(s) + np.log(s_next)) / 2))
+        denoised = ds_predict(x, s, embedding, features)
+        d = (x - denoised) / s
+        x_mid = x + d * (s_mid - s)
+        denoised_mid = ds_predict(x_mid, s_mid, embedding, features)
+        d_mid = (x_mid - denoised_mid) / s_mid
+        x = x + d_mid * (s_next - s)
+    return x  # (1, 1, 256)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--text", default=DEFAULT_TEXT)
+    ap.add_argument("--reference-wav", type=Path, required=True)
+    ap.add_argument("--checkpoint", type=Path, default=DEFAULT_CHECKPOINT)
+    ap.add_argument("--coreml-dir", type=Path, default=COREML_DIR)
+    ap.add_argument("--out", type=Path, default=Path("/tmp/styletts2-e2e/coreml.wav"))
+    ap.add_argument("--diffusion-steps", type=int, default=5)
+    ap.add_argument("--alpha", type=float, default=0.3)
+    ap.add_argument("--beta", type=float, default=0.7)
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+
+    timings = {}
+    t_total = time.time()
+
+    print("[e2e] loading PyTorch helpers (style/predictor encoders only)…")
+    t0 = time.time()
+    modules, cfg = load_inference_modules(args.checkpoint)
+    timings["load_pytorch"] = time.time() - t0
+
+    print("[e2e] phonemize + ref_s …")
+    t0 = time.time()
+    tokens = phonemize(args.text)
+    T_tok = tokens.shape[-1]
+    tok_bucket = pick_bucket(T_tok, TOKEN_BUCKETS)
+    ref_s = compute_ref_s(modules, args.reference_wav)
+    timings["frontend"] = time.time() - t0
+    print(f"[e2e]   T_tok={T_tok}  tok_bucket={tok_bucket}  ref_s={tuple(ref_s.shape)}")
+
+    import coremltools as ct
+
+    def load(name):
+        return ct.models.MLModel(str(args.coreml_dir / name))
+
+    print(f"[e2e] loading CoreML packages (T_tok bucket={tok_bucket})…")
+    t0 = time.time()
+    tp = load(f"styletts2_text_predictor_{tok_bucket}.mlpackage")
+    ds = load(f"styletts2_diffusion_step_{tok_bucket}.mlpackage")
+    fn = load("styletts2_f0n_energy.mlpackage")
+    timings["load_text+diff+f0n"] = time.time() - t0
+
+    # ---- Stage A: text_predictor ----
+    t0 = time.time()
+    tokens_pad = np.zeros((1, tok_bucket), dtype=np.int32)
+    tokens_pad[0, :T_tok] = tokens.numpy().astype(np.int32)[0]
+    style_half = ref_s[:, :128].numpy().astype(np.float32)
+    A = tp.predict({"tokens": tokens_pad, "style": style_half})
+    timings["A_text_predictor"] = time.time() - t0
+
+    t_en = A["t_en"][..., :T_tok]                        # (1, 512, T_tok)
+    d_full = A["d"][:, :T_tok, :]                        # (1, T_tok, 640)
+    pred_dur_log = A["pred_dur_log"][:, :T_tok, :]       # (1, T_tok, 50)
+    bert_dur = A["bert_dur"][:, :T_tok, :]               # (1, T_tok, 768)
+
+    pred_dur = (
+        torch.round(torch.sigmoid(torch.from_numpy(pred_dur_log)).sum(dim=-1).squeeze())
+        .clamp(min=1)
+        .long()
+        .numpy()
+    )
+    T_mel = int(pred_dur.sum())
+    mel_bucket = pick_bucket(T_mel, MEL_BUCKETS)
+    print(f"[e2e]   T_mel={T_mel}  mel_bucket={mel_bucket}")
+
+    # ---- Stage B: diffusion sampler ----
+    t0 = time.time()
+    np.random.seed(args.seed)
+    noise = np.random.randn(1, 1, 256).astype(np.float32)
+    bert_pad = np.zeros((1, tok_bucket, bert_dur.shape[-1]), dtype=np.float32)
+    bert_pad[:, :T_tok, :] = bert_dur
+    features = ref_s.numpy().astype(np.float32)
+    sigmas = karras_sigmas(args.diffusion_steps)
+
+    def ds_predict(x, s, emb, feats):
+        return ds.predict({
+            "x_noisy": x.astype(np.float32),
+            "sigma": np.array([s], dtype=np.float32),
+            "embedding": emb.astype(np.float32),
+            "features": feats.astype(np.float32),
+        })["denoised"]
+
+    s_pred = adpm2_sample(ds_predict, noise, sigmas, bert_pad, features).squeeze(1)
+    timings["B_diffusion"] = time.time() - t0
+
+    s = s_pred[:, 128:]
+    ref = s_pred[:, :128]
+    ref = args.alpha * ref + (1 - args.alpha) * ref_s[:, :128].numpy()
+    s = args.beta * s + (1 - args.beta) * ref_s[:, 128:].numpy()
+
+    # ---- Build alignment, compute en/asr ----
+    t0 = time.time()
+    aln = np.zeros((T_tok, T_mel), dtype=np.float32)
+    c = 0
+    for i in range(T_tok):
+        n = int(pred_dur[i])
+        aln[i, c:c + n] = 1.0
+        c += n
+    aln = aln[None]                                       # (1, T_tok, T_mel)
+
+    # d_full is (1, T_tok, 640); transpose → (1, 640, T_tok); @ aln → (1, 640, T_mel)
+    en = np.matmul(d_full.transpose(0, 2, 1), aln)        # (1, 640, T_mel)
+    asr = np.matmul(t_en, aln)                            # (1, 512, T_mel)
+
+    # hifigan shift-right by 1 frame
+    en_s = np.zeros_like(en)
+    en_s[:, :, 0] = en[:, :, 0]
+    en_s[:, :, 1:] = en[:, :, :-1]
+    asr_s = np.zeros_like(asr)
+    asr_s[:, :, 0] = asr[:, :, 0]
+    asr_s[:, :, 1:] = asr[:, :, :-1]
+    en, asr = en_s, asr_s
+    timings["align_build"] = time.time() - t0
+
+    # ---- Stage C: f0n_energy ----
+    t0 = time.time()
+    en_pad = np.zeros((1, 640, mel_bucket), dtype=np.float32)
+    en_pad[:, :, :T_mel] = en
+    C = fn.predict({"en": en_pad, "s": s.astype(np.float32)})
+    F0 = C["F0"][:, :2 * T_mel]
+    N = C["N"][:, :2 * T_mel]
+    timings["C_f0n_energy"] = time.time() - t0
+
+    # ---- Stage D: decoder bucket ----
+    t0 = time.time()
+    decoder = load(f"styletts2_decoder_{mel_bucket}.mlpackage")
+    timings["D_load_decoder"] = time.time() - t0
+
+    t0 = time.time()
+    asr_pad = np.zeros((1, 512, mel_bucket), dtype=np.float32)
+    asr_pad[:, :, :T_mel] = asr
+    F0_pad = np.zeros((1, 2 * mel_bucket), dtype=np.float32)
+    F0_pad[:, :F0.shape[1]] = F0
+    N_pad = np.zeros((1, 2 * mel_bucket), dtype=np.float32)
+    N_pad[:, :N.shape[1]] = N
+    D = decoder.predict({
+        "asr": asr_pad,
+        "F0_curve": F0_pad,
+        "N": N_pad,
+        "s": ref.astype(np.float32),
+    })
+    timings["D_decode"] = time.time() - t0
+
+    wav = D["waveform"].squeeze()[: T_mel * 600]
+    if wav.shape[-1] > 50:
+        wav = wav[..., :-50]
+    sf.write(str(args.out), wav, 24000)
+
+    timings["total"] = time.time() - t_total
+    audio_dur = len(wav) / 24000.0
+    inference_time = sum(
+        timings[k] for k in (
+            "A_text_predictor", "B_diffusion", "align_build",
+            "C_f0n_energy", "D_decode",
+        )
+    )
+
+    print()
+    print(f"[e2e] wrote {args.out} ({audio_dur:.2f}s)")
+    print()
+    print("[e2e] === Timings ===")
+    for k, v in timings.items():
+        print(f"  {k:24s}  {v*1000:8.1f} ms")
+    print()
+    print(f"  inference (A+B+align+C+D_decode): {inference_time*1000:8.1f} ms")
+    print(f"  audio duration:                   {audio_dur*1000:8.1f} ms")
+    print(f"  RTFx (audio/inference):           {audio_dur/inference_time:8.2f}×")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/tts/styletts2/scripts/99c_e2e_optimized.py
+++ b/models/tts/styletts2/scripts/99c_e2e_optimized.py
@@ -1,0 +1,191 @@
+"""End-to-end with int8 text_predictor + diffusion fixed at bucket=512."""
+from __future__ import annotations
+import sys, time
+from pathlib import Path
+import numpy as np
+import soundfile as sf
+import torch
+
+PKG = Path("/Users/kikow/brandon/voicelink/mobius-styletts2/models/tts/styletts2")
+sys.path.insert(0, str(PKG / "scripts"))
+from _styletts2_lib import (  # noqa: E402
+    DEFAULT_CHECKPOINT, COREML_DIR, load_inference_modules, register_coreml_op_shims,
+)
+register_coreml_op_shims()
+import coremltools as ct  # noqa: E402
+
+TEXT = "The quick brown fox jumps over the lazy dog."
+REF_WAV = Path("/tmp/styletts2-e2e/coreml.wav")
+OUT = Path("/tmp/styletts2-e2e/coreml_int8_diff512.wav")
+ALPHA, BETA, SEED = 0.3, 0.7, 0
+TOK_BUCKETS = (32, 64, 128, 256, 512)
+MEL_BUCKETS = (256, 512, 1024, 2048, 4096)
+DIFF_BUCKET = 512  # only bucket retained
+
+def pick(n, b):
+    for x in b:
+        if n <= x: return x
+    raise ValueError
+
+def phonemize(text):
+    import phonemizer
+    from nltk.tokenize import word_tokenize
+    from text_utils import TextCleaner
+    backend = phonemizer.backend.EspeakBackend(language="en-us", preserve_punctuation=True, with_stress=True)
+    ps = backend.phonemize([text.strip()])
+    ps = " ".join(word_tokenize(ps[0]))
+    cleaner = TextCleaner(); tokens = cleaner(ps); tokens.insert(0, 0)
+    return torch.LongTensor(tokens).unsqueeze(0)
+
+def compute_ref_s(modules, wav_path):
+    import librosa, torchaudio
+    to_mel = torchaudio.transforms.MelSpectrogram(n_mels=80, n_fft=2048, win_length=1200, hop_length=300)
+    wave, _ = librosa.load(str(wav_path), sr=24000)
+    audio, _ = librosa.effects.trim(wave, top_db=30)
+    mel = to_mel(torch.from_numpy(audio).float())
+    mel = (torch.log(1e-5 + mel.unsqueeze(0)) + 4.0) / 4.0
+    with torch.no_grad():
+        ref_s = modules["style_encoder"](mel.unsqueeze(1))
+        ref_p = modules["predictor_encoder"](mel.unsqueeze(1))
+    return torch.cat([ref_s, ref_p], dim=1)
+
+def karras(n, smin=0.0001, smax=3.0, rho=9.0):
+    ri = 1.0/rho; r = np.linspace(0,1,n).astype(np.float64)
+    s = (smax**ri + r*(smin**ri - smax**ri))**rho
+    return np.concatenate([s, [0.0]]).astype(np.float32)
+
+def adpm2(pf, noise, sigmas, emb, feat):
+    x = noise.astype(np.float32)*float(sigmas[0])
+    for i in range(len(sigmas)-1):
+        s, sn = float(sigmas[i]), float(sigmas[i+1])
+        if sn == 0.0:
+            d = (x - pf(x, s, emb, feat))/s; x = x + d*(sn-s); continue
+        sm = float(np.exp((np.log(s)+np.log(sn))/2))
+        d = (x - pf(x, s, emb, feat))/s; xm = x + d*(sm-s)
+        dm = (xm - pf(xm, sm, emb, feat))/sm; x = x + dm*(sn-s)
+    return x
+
+def main():
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    timings = {}; t_total = time.time()
+
+    t0 = time.time(); modules, cfg = load_inference_modules(DEFAULT_CHECKPOINT)
+    timings["load_pytorch"] = time.time()-t0
+
+    t0 = time.time()
+    tokens = phonemize(TEXT); T = tokens.shape[-1]; tb = pick(T, TOK_BUCKETS)
+    ref_s = compute_ref_s(modules, REF_WAV)
+    timings["frontend"] = time.time()-t0
+    print(f"T_tok={T}  tp_bucket={tb}  diff_bucket={DIFF_BUCKET}")
+
+    t0 = time.time()
+    tp = ct.models.MLModel(str(COREML_DIR / f"styletts2_text_predictor_{tb}_int8.mlpackage"), compute_units=ct.ComputeUnit.ALL)
+    ds = ct.models.MLModel(str(COREML_DIR / f"styletts2_diffusion_step_{DIFF_BUCKET}.mlpackage"), compute_units=ct.ComputeUnit.CPU_ONLY)
+    fn = ct.models.MLModel(str(COREML_DIR / "styletts2_f0n_energy.mlpackage"), compute_units=ct.ComputeUnit.ALL)
+    timings["load_models"] = time.time()-t0
+
+    # warmup
+    t0 = time.time()
+    _wt = np.zeros((1, tb), dtype=np.int32)
+    _ws = np.zeros((1, 128), dtype=np.float32)
+    tp.predict({"tokens": _wt, "style": _ws})
+    ds.predict({
+        "x_noisy": np.zeros((1,1,256), dtype=np.float32),
+        "sigma": np.array([1.0], dtype=np.float32),
+        "embedding": np.zeros((1, DIFF_BUCKET, 768), dtype=np.float32),
+        "features": np.zeros((1, 256), dtype=np.float32),
+    })
+    fn.predict({"en": np.zeros((1, 640, 256), dtype=np.float32), "s": np.zeros((1, 128), dtype=np.float32)})
+    timings["warmup_models"] = time.time()-t0
+
+    t0 = time.time()
+    tok_pad = np.zeros((1, tb), dtype=np.int32); tok_pad[0, :T] = tokens.numpy().astype(np.int32)[0]
+    A = tp.predict({"tokens": tok_pad, "style": ref_s[:,:128].numpy().astype(np.float32)})
+    timings["A"] = time.time()-t0
+
+    t_en = A["t_en"][..., :T]; d_full = A["d"][:, :T, :]
+    pred_log = A["pred_dur_log"][:, :T, :]; bert_dur = A["bert_dur"][:, :T, :]
+    pred_dur = (torch.round(torch.sigmoid(torch.from_numpy(pred_log)).sum(dim=-1).squeeze()).clamp(min=1).long().numpy())
+    Tm = int(pred_dur.sum()); mb = pick(Tm, MEL_BUCKETS)
+    print(f"T_mel={Tm}  bucket={mb}")
+
+    t0 = time.time()
+    np.random.seed(SEED)
+    noise = np.random.randn(1,1,256).astype(np.float32)
+    # pad bert_dur to DIFF_BUCKET (=512), not to tp bucket
+    bp = np.zeros((1, DIFF_BUCKET, bert_dur.shape[-1]), dtype=np.float32); bp[:,:T,:] = bert_dur
+    sigmas = karras(5); feats = ref_s.numpy().astype(np.float32)
+    def pf(x,s,e,f):
+        return ds.predict({"x_noisy":x.astype(np.float32),"sigma":np.array([s],dtype=np.float32),"embedding":e.astype(np.float32),"features":f.astype(np.float32)})["denoised"]
+    s_pred = adpm2(pf, noise, sigmas, bp, feats).squeeze(1)
+    timings["B"] = time.time()-t0
+
+    s = s_pred[:,128:]; ref = s_pred[:,:128]
+    ref = ALPHA*ref + (1-ALPHA)*ref_s[:,:128].numpy()
+    s = BETA*s + (1-BETA)*ref_s[:,128:].numpy()
+
+    t0 = time.time()
+    aln = np.zeros((T, Tm), dtype=np.float32); c = 0
+    for i in range(T):
+        n = int(pred_dur[i]); aln[i, c:c+n] = 1.0; c += n
+    aln = aln[None]
+    en = np.matmul(d_full.transpose(0,2,1), aln); asr = np.matmul(t_en, aln)
+    en_s = np.zeros_like(en); en_s[:,:,0]=en[:,:,0]; en_s[:,:,1:]=en[:,:,:-1]
+    asr_s = np.zeros_like(asr); asr_s[:,:,0]=asr[:,:,0]; asr_s[:,:,1:]=asr[:,:,:-1]
+    en, asr = en_s, asr_s
+    timings["align"] = time.time()-t0
+
+    t0 = time.time()
+    en_pad = np.zeros((1,640,mb),dtype=np.float32); en_pad[:,:,:Tm] = en
+    C = fn.predict({"en":en_pad, "s":s.astype(np.float32)})
+    F0 = C["F0"][:,:2*Tm]; N = C["N"][:,:2*Tm]
+    timings["C"] = time.time()-t0
+
+    t0 = time.time()
+    decoder = ct.models.MLModel(str(COREML_DIR / f"styletts2_decoder_{mb}.mlpackage"), compute_units=ct.ComputeUnit.CPU_ONLY)
+    timings["D_load"] = time.time()-t0
+
+    # warmup decoder
+    t0 = time.time()
+    decoder.predict({
+        "asr": np.zeros((1, 512, mb), dtype=np.float32),
+        "F0_curve": np.zeros((1, 2*mb), dtype=np.float32),
+        "N": np.zeros((1, 2*mb), dtype=np.float32),
+        "s": np.zeros((1, 128), dtype=np.float32),
+    })
+    timings["D_warmup"] = time.time()-t0
+
+    t0 = time.time()
+    asr_p = np.zeros((1,512,mb),dtype=np.float32); asr_p[:,:,:Tm] = asr
+    F0p = np.zeros((1,2*mb),dtype=np.float32); F0p[:,:F0.shape[1]] = F0
+    Np = np.zeros((1,2*mb),dtype=np.float32); Np[:,:N.shape[1]] = N
+    D = decoder.predict({"asr":asr_p,"F0_curve":F0p,"N":Np,"s":ref.astype(np.float32)})
+    timings["D"] = time.time()-t0
+
+    wav = D["waveform"].squeeze()[:Tm*600]
+    if wav.shape[-1] > 50: wav = wav[...,:-50]
+    sf.write(str(OUT), wav, 24000)
+
+    timings["total"] = time.time()-t_total
+    audio = len(wav)/24000.0
+    inf = timings["A"]+timings["B"]+timings["align"]+timings["C"]+timings["D"]
+    print(f"\n--- Timings ---")
+    for k,v in timings.items(): print(f"  {k:14s}  {v*1000:8.1f} ms")
+    print(f"  inference        {inf*1000:8.1f} ms")
+    print(f"  audio            {audio*1000:8.1f} ms")
+    print(f"  RTFx             {audio/inf:8.2f}×")
+
+    # Spectral comparison vs fp16 e2e baseline
+    import torchaudio as ta
+    fp16_wav, _ = sf.read("/tmp/styletts2-e2e/coreml_optimal.wav")
+    n = min(len(wav), len(fp16_wav))
+    a = wav[:n].astype(np.float64); b = fp16_wav[:n].astype(np.float64)
+    to_mel = ta.transforms.MelSpectrogram(sample_rate=24000, n_mels=80, n_fft=2048, win_length=1200, hop_length=300)
+    ma = to_mel(torch.from_numpy(a).float()).numpy()
+    mb_ = to_mel(torch.from_numpy(b).float()).numpy()
+    la = np.log(ma+1e-5).flatten(); lb = np.log(mb_+1e-5).flatten()
+    mc = np.dot(la,lb)/(np.linalg.norm(la)*np.linalg.norm(lb)+1e-9)
+    print(f"\nlog-mel cos(int8+diff512 vs fp16 e2e): {mc:.4f}")
+
+if __name__ == "__main__":
+    main()

--- a/models/tts/styletts2/scripts/99c_e2e_optimized.py
+++ b/models/tts/styletts2/scripts/99c_e2e_optimized.py
@@ -1,22 +1,20 @@
 """End-to-end with int8 text_predictor + diffusion fixed at bucket=512."""
 from __future__ import annotations
+import argparse
 import sys, time
 from pathlib import Path
 import numpy as np
 import soundfile as sf
 import torch
 
-PKG = Path("/Users/kikow/brandon/voicelink/mobius-styletts2/models/tts/styletts2")
-sys.path.insert(0, str(PKG / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _styletts2_lib import (  # noqa: E402
     DEFAULT_CHECKPOINT, COREML_DIR, load_inference_modules, register_coreml_op_shims,
 )
 register_coreml_op_shims()
 import coremltools as ct  # noqa: E402
 
-TEXT = "The quick brown fox jumps over the lazy dog."
-REF_WAV = Path("/tmp/styletts2-e2e/coreml.wav")
-OUT = Path("/tmp/styletts2-e2e/coreml_int8_diff512.wav")
+DEFAULT_TEXT = "The quick brown fox jumps over the lazy dog."
 ALPHA, BETA, SEED = 0.3, 0.7, 0
 TOK_BUCKETS = (32, 64, 128, 256, 512)
 MEL_BUCKETS = (256, 512, 1024, 2048, 4096)
@@ -66,22 +64,35 @@ def adpm2(pf, noise, sigmas, emb, feat):
     return x
 
 def main():
-    OUT.parent.mkdir(parents=True, exist_ok=True)
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--text", default=DEFAULT_TEXT)
+    ap.add_argument("--reference-wav", type=Path, required=True,
+                    help="Reference WAV for the speaker style encoder.")
+    ap.add_argument("--checkpoint", type=Path, default=DEFAULT_CHECKPOINT)
+    ap.add_argument("--coreml-dir", type=Path, default=COREML_DIR)
+    ap.add_argument("--out", type=Path,
+                    default=Path("/tmp/styletts2-e2e/coreml_int8_diff512.wav"))
+    ap.add_argument("--baseline-wav", type=Path, default=None,
+                    help="Optional fp16 e2e baseline WAV for spectral cosine "
+                    "comparison. Typically the output of 99b_e2e_coreml.py.")
+    args = ap.parse_args()
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
     timings = {}; t_total = time.time()
 
-    t0 = time.time(); modules, cfg = load_inference_modules(DEFAULT_CHECKPOINT)
+    t0 = time.time(); modules, cfg = load_inference_modules(args.checkpoint)
     timings["load_pytorch"] = time.time()-t0
 
     t0 = time.time()
-    tokens = phonemize(TEXT); T = tokens.shape[-1]; tb = pick(T, TOK_BUCKETS)
-    ref_s = compute_ref_s(modules, REF_WAV)
+    tokens = phonemize(args.text); T = tokens.shape[-1]; tb = pick(T, TOK_BUCKETS)
+    ref_s = compute_ref_s(modules, args.reference_wav)
     timings["frontend"] = time.time()-t0
     print(f"T_tok={T}  tp_bucket={tb}  diff_bucket={DIFF_BUCKET}")
 
     t0 = time.time()
-    tp = ct.models.MLModel(str(COREML_DIR / f"styletts2_text_predictor_{tb}_int8.mlpackage"), compute_units=ct.ComputeUnit.ALL)
-    ds = ct.models.MLModel(str(COREML_DIR / f"styletts2_diffusion_step_{DIFF_BUCKET}.mlpackage"), compute_units=ct.ComputeUnit.CPU_ONLY)
-    fn = ct.models.MLModel(str(COREML_DIR / "styletts2_f0n_energy.mlpackage"), compute_units=ct.ComputeUnit.ALL)
+    tp = ct.models.MLModel(str(args.coreml_dir / f"styletts2_text_predictor_{tb}_int8.mlpackage"), compute_units=ct.ComputeUnit.ALL)
+    ds = ct.models.MLModel(str(args.coreml_dir / f"styletts2_diffusion_step_{DIFF_BUCKET}.mlpackage"), compute_units=ct.ComputeUnit.CPU_AND_GPU)
+    fn = ct.models.MLModel(str(args.coreml_dir / "styletts2_f0n_energy.mlpackage"), compute_units=ct.ComputeUnit.ALL)
     timings["load_models"] = time.time()-t0
 
     # warmup
@@ -142,7 +153,7 @@ def main():
     timings["C"] = time.time()-t0
 
     t0 = time.time()
-    decoder = ct.models.MLModel(str(COREML_DIR / f"styletts2_decoder_{mb}.mlpackage"), compute_units=ct.ComputeUnit.CPU_ONLY)
+    decoder = ct.models.MLModel(str(args.coreml_dir / f"styletts2_decoder_{mb}.mlpackage"), compute_units=ct.ComputeUnit.CPU_AND_GPU)
     timings["D_load"] = time.time()-t0
 
     # warmup decoder
@@ -164,7 +175,7 @@ def main():
 
     wav = D["waveform"].squeeze()[:Tm*600]
     if wav.shape[-1] > 50: wav = wav[...,:-50]
-    sf.write(str(OUT), wav, 24000)
+    sf.write(str(args.out), wav, 24000)
 
     timings["total"] = time.time()-t_total
     audio = len(wav)/24000.0
@@ -175,17 +186,22 @@ def main():
     print(f"  audio            {audio*1000:8.1f} ms")
     print(f"  RTFx             {audio/inf:8.2f}×")
 
-    # Spectral comparison vs fp16 e2e baseline
-    import torchaudio as ta
-    fp16_wav, _ = sf.read("/tmp/styletts2-e2e/coreml_optimal.wav")
-    n = min(len(wav), len(fp16_wav))
-    a = wav[:n].astype(np.float64); b = fp16_wav[:n].astype(np.float64)
-    to_mel = ta.transforms.MelSpectrogram(sample_rate=24000, n_mels=80, n_fft=2048, win_length=1200, hop_length=300)
-    ma = to_mel(torch.from_numpy(a).float()).numpy()
-    mb_ = to_mel(torch.from_numpy(b).float()).numpy()
-    la = np.log(ma+1e-5).flatten(); lb = np.log(mb_+1e-5).flatten()
-    mc = np.dot(la,lb)/(np.linalg.norm(la)*np.linalg.norm(lb)+1e-9)
-    print(f"\nlog-mel cos(int8+diff512 vs fp16 e2e): {mc:.4f}")
+    # Optional spectral comparison vs fp16 e2e baseline (e.g. output of
+    # 99b_e2e_coreml.py). Skipped if --baseline-wav is not provided or the
+    # file is missing.
+    if args.baseline_wav is not None and args.baseline_wav.exists():
+        import torchaudio as ta
+        fp16_wav, _ = sf.read(str(args.baseline_wav))
+        n = min(len(wav), len(fp16_wav))
+        a = wav[:n].astype(np.float64); b = fp16_wav[:n].astype(np.float64)
+        to_mel = ta.transforms.MelSpectrogram(sample_rate=24000, n_mels=80, n_fft=2048, win_length=1200, hop_length=300)
+        ma = to_mel(torch.from_numpy(a).float()).numpy()
+        mb_ = to_mel(torch.from_numpy(b).float()).numpy()
+        la = np.log(ma+1e-5).flatten(); lb = np.log(mb_+1e-5).flatten()
+        mc = np.dot(la,lb)/(np.linalg.norm(la)*np.linalg.norm(lb)+1e-9)
+        print(f"\nlog-mel cos(int8+diff512 vs fp16 e2e): {mc:.4f}")
+    elif args.baseline_wav is not None:
+        print(f"\n[skip] --baseline-wav not found: {args.baseline_wav}")
 
 if __name__ == "__main__":
     main()

--- a/models/tts/styletts2/scripts/99c_e2e_optimized.py
+++ b/models/tts/styletts2/scripts/99c_e2e_optimized.py
@@ -1,4 +1,4 @@
-"""End-to-end with int8 text_predictor + diffusion fixed at bucket=512."""
+"""End-to-end with fp16 text_predictor + diffusion fixed at bucket=512."""
 from __future__ import annotations
 import argparse
 import sys, time
@@ -71,7 +71,7 @@ def main():
     ap.add_argument("--checkpoint", type=Path, default=DEFAULT_CHECKPOINT)
     ap.add_argument("--coreml-dir", type=Path, default=COREML_DIR)
     ap.add_argument("--out", type=Path,
-                    default=Path("/tmp/styletts2-e2e/coreml_int8_diff512.wav"))
+                    default=Path("/tmp/styletts2-e2e/coreml_fp16_diff512.wav"))
     ap.add_argument("--baseline-wav", type=Path, default=None,
                     help="Optional fp16 e2e baseline WAV for spectral cosine "
                     "comparison. Typically the output of 99b_e2e_coreml.py.")
@@ -90,7 +90,9 @@ def main():
     print(f"T_tok={T}  tp_bucket={tb}  diff_bucket={DIFF_BUCKET}")
 
     t0 = time.time()
-    tp = ct.models.MLModel(str(args.coreml_dir / f"styletts2_text_predictor_{tb}_int8.mlpackage"), compute_units=ct.ComputeUnit.ALL)
+    # int8 PTQ on text_predictor was dropped before ship (see coreml/PRECISION.md);
+    # the build pipeline produces fp16 .mlpackage only.
+    tp = ct.models.MLModel(str(args.coreml_dir / f"styletts2_text_predictor_{tb}.mlpackage"), compute_units=ct.ComputeUnit.ALL)
     ds = ct.models.MLModel(str(args.coreml_dir / f"styletts2_diffusion_step_{DIFF_BUCKET}.mlpackage"), compute_units=ct.ComputeUnit.CPU_AND_GPU)
     fn = ct.models.MLModel(str(args.coreml_dir / "styletts2_f0n_energy.mlpackage"), compute_units=ct.ComputeUnit.ALL)
     timings["load_models"] = time.time()-t0
@@ -199,7 +201,7 @@ def main():
         mb_ = to_mel(torch.from_numpy(b).float()).numpy()
         la = np.log(ma+1e-5).flatten(); lb = np.log(mb_+1e-5).flatten()
         mc = np.dot(la,lb)/(np.linalg.norm(la)*np.linalg.norm(lb)+1e-9)
-        print(f"\nlog-mel cos(int8+diff512 vs fp16 e2e): {mc:.4f}")
+        print(f"\nlog-mel cos(fp16+diff512 vs baseline): {mc:.4f}")
     elif args.baseline_wav is not None:
         print(f"\n[skip] --baseline-wav not found: {args.baseline_wav}")
 

--- a/models/tts/styletts2/scripts/_styletts2_lib.py
+++ b/models/tts/styletts2/scripts/_styletts2_lib.py
@@ -70,6 +70,92 @@ def register_coreml_op_shims() -> None:
     register_coreml_op_shims._done = True  # type: ignore[attr-defined]
 
 
+# --- SineGen op-translation fix (decoder export only) -------------------------
+
+# `Modules/hifigan.py::SineGen._f02sine` triggers three coremltools op
+# translation bugs that turn the harmonic source into garbage and produce
+# robotic CoreML audio:
+#
+#   1. `(rad / sr) % 1`    : aten::remainder is mistranslated.
+#   2. `F.interpolate(scale=1/300)` downsample : NaN under fp16 lowering.
+#   3. `F.interpolate(scale=300)`   upsample   : NaN under fp16 lowering.
+#
+# Fix (per-bucket): rewrite `_f02sine` so the modulo becomes `x - floor(x)`,
+# the downsample becomes a stride slice `[..., ::scale, ...]`, and the
+# upsample becomes a manual linear lerp built from `repeat_interleave` and
+# arithmetic — all CoreML-friendly primitives. The lerp's `fracs` index
+# (`(arange(T_audio) % 300) / 300`) is constant-folded at trace time using a
+# Python-int closure so the converter never sees the offending `aten::remainder`
+# in the trace either.
+#
+# This must be re-applied PER BUCKET because `fracs` depends on the bucket's
+# `T_audio = T_mel * 2 * UPSAMPLE_SCALE`. See PHASE6_FP16_DECODER.md.
+
+UPSAMPLE_SCALE = 300
+
+
+def install_sinegen_v2_constfold_fix(t_mel: int) -> None:
+    """Patch `SineGen._f02sine` and `SineGen.forward` for one mel bucket.
+
+    Idempotent across calls — repeated calls re-bind the patch to the new
+    `t_mel`. The original methods are stashed on the class once.
+    """
+    import numpy as _np
+    import torch as _torch
+    from Modules.hifigan import SineGen  # type: ignore
+
+    t_audio = t_mel * 2 * UPSAMPLE_SCALE
+    fracs_np = (
+        _np.arange(t_audio, dtype=_np.float32) % UPSAMPLE_SCALE
+    ) / float(UPSAMPLE_SCALE)
+    fracs_tensor = _torch.from_numpy(
+        fracs_np.reshape(1, t_audio, 1)
+    ).contiguous()
+
+    def _f02sine_constfold(self, f0_values):
+        rad_div = f0_values / self.sampling_rate
+        rad_mod = rad_div - _torch.floor(rad_div)
+        if not self.flag_for_pulse:
+            rad_down = rad_mod[:, ::UPSAMPLE_SCALE, :]
+            phase = _torch.cumsum(rad_down, dim=1) * 2 * float(_np.pi)
+            phase_scaled = phase * self.upsample_scale
+            left = phase_scaled.repeat_interleave(UPSAMPLE_SCALE, dim=1)
+            last = phase_scaled[:, -1:, :]
+            shifted = _torch.cat([phase_scaled[:, 1:, :], last], dim=1)
+            right = shifted.repeat_interleave(UPSAMPLE_SCALE, dim=1)
+            fracs = fracs_tensor.to(phase_scaled.device, phase_scaled.dtype)
+            phase_up = left * (1.0 - fracs) + right * fracs
+            return _torch.sin(phase_up)
+        # Pulse-train branch is never used in inference (flag_for_pulse=False
+        # in Generator). Keep upstream behavior if anyone flips it.
+        return SineGen._f02sine_original(self, f0_values)  # type: ignore[attr-defined]
+
+    def _forward_deterministic(self, f0):
+        # Drop the `rand_ini`/randn noise so the trace is deterministic and
+        # CoreML doesn't bake the sampled noise as a constant. We replace the
+        # noise term with a phase-locked sine of the harmonics — same RMS,
+        # same uv masking, no stochasticity.
+        sg = self
+        harm_mul = _torch.FloatTensor(
+            [[range(1, sg.harmonic_num + 2)]]
+        ).to(f0.device)
+        fn = _torch.multiply(f0, harm_mul)
+        sines = _f02sine_constfold(sg, fn)
+        sine_waves = sines * sg.sine_amp
+        uv = sg._f02uv(f0)
+        noise_amp = uv * sg.noise_std + (1 - uv) * sg.sine_amp / 3
+        noise = noise_amp * _torch.sin(fn * 100.0)
+        sine_waves = sine_waves * uv + noise
+        return sine_waves, uv, noise
+
+    if not hasattr(SineGen, "_f02sine_original"):
+        SineGen._f02sine_original = SineGen._f02sine  # type: ignore[attr-defined]
+    if not hasattr(SineGen, "_forward_original"):
+        SineGen._forward_original = SineGen.forward  # type: ignore[attr-defined]
+    SineGen._f02sine = _f02sine_constfold
+    SineGen.forward = _forward_deterministic
+
+
 # --- Compact LibriTTS config (mirrors Configs/config_libritts.yml) ------------
 
 
@@ -169,40 +255,12 @@ def _build_modules(cfg: LibriTTSConfig):
 
     AttentionBase.forward = _attention_forward_matmul
 
-    # `SineGen._f02sine` (Modules/hifigan.py) uses `F.interpolate(..., mode="linear",
-    # scale_factor=1/300)` which trips coremltools' upsample_linear1d translator
-    # ("recompute_scale_factor=False, align_corners=False with float output size
-    # is not supported"). Set align_corners=True — quality impact is negligible
-    # and CoreML's upsample_bilinear supports this configuration.
-    import numpy as _np
-    from Modules.hifigan import SineGen  # type: ignore
-
-    def _f02sine_align_corners(self, f0_values):
-        rad_values = (f0_values / self.sampling_rate) % 1
-        if not self.flag_for_pulse:
-            rad_values = F.interpolate(
-                rad_values.transpose(1, 2),
-                scale_factor=1.0 / self.upsample_scale,
-                mode="linear",
-                align_corners=True,
-            ).transpose(1, 2)
-            phase = torch.cumsum(rad_values, dim=1) * 2 * _np.pi
-            phase = F.interpolate(
-                phase.transpose(1, 2) * self.upsample_scale,
-                scale_factor=float(self.upsample_scale),
-                mode="linear",
-                align_corners=True,
-            ).transpose(1, 2)
-            sines = torch.sin(phase)
-        else:
-            # Pulse-train branch is never used in inference (flag_for_pulse=False
-            # in Generator). Keep upstream behavior if anyone flips it.
-            sines = SineGen._f02sine_original(self, f0_values)  # type: ignore[attr-defined]
-        return sines
-
-    if not hasattr(SineGen, "_f02sine_original"):
-        SineGen._f02sine_original = SineGen._f02sine  # type: ignore[attr-defined]
-    SineGen._f02sine = _f02sine_align_corners
+    # SineGen op-translation fix is now applied per-bucket from the decoder
+    # export script via `install_sinegen_v2_constfold_fix(t_mel)`. We do NOT
+    # install any default shim here — `_build_modules` is also called by the
+    # text-predictor / diffusion / F0n exports, none of which trace through
+    # SineGen, so they don't need it. See PHASE6_FP16_DECODER.md for the full
+    # diagnosis of the three coremltools op-translation bugs in `_f02sine`.
 
     if cfg.decoder_type == "hifigan":
         from Modules.hifigan import Decoder  # type: ignore

--- a/models/tts/styletts2/scripts/_styletts2_lib.py
+++ b/models/tts/styletts2/scripts/_styletts2_lib.py
@@ -1,0 +1,548 @@
+"""Shared loader for the StyleTTS2-LibriTTS inference modules.
+
+All export scripts (01–04) call `load_inference_modules()` to get the same set
+of `nn.Module`s in eval mode with their parameters loaded from the stripped
+checkpoint produced by `00_fetch_weights.py`.
+
+Why a shared helper:
+  - The upstream `models.build_model(...)` insists on building discriminators
+    and a JDC pitch extractor and an ASR aligner that we don't need at
+    inference. We only need: text_encoder, predictor (incl. F0Ntrain),
+    style_encoder, predictor_encoder, bert, bert_encoder, decoder, diffusion.
+  - The upstream config lives in YAML, but the inference-relevant fields fit
+    in a compact dataclass — no need to drag in `munch`/`yaml` semantics.
+  - All forwards used at inference must be traceable. We provide thin wrappers
+    that drop `pack_padded_sequence` (no-op for B=1 + lengths==seq_len) and
+    avoid `.cpu().numpy()` calls.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+# --- Vendor path setup --------------------------------------------------------
+
+THIS_DIR = Path(__file__).resolve().parent
+PKG_DIR = THIS_DIR.parent  # models/tts/styletts2
+VENDOR_DIR = PKG_DIR / "vendor" / "StyleTTS2"
+DEFAULT_CHECKPOINT = PKG_DIR / "checkpoints" / "styletts2_libritts_inference.pt"
+COREML_DIR = PKG_DIR / "coreml"
+PLBERT_DIR = VENDOR_DIR / "Utils" / "PLBERT"
+
+if str(VENDOR_DIR) not in sys.path:
+    sys.path.insert(0, str(VENDOR_DIR))
+
+
+def register_coreml_op_shims() -> None:
+    """Register torch op handlers for ops coremltools 8.x doesn't natively map.
+
+    Currently:
+      - aten::multiply  → coremltools `mb.mul` (used by SineGen in hifigan.py).
+
+    Idempotent: register once per process.
+    """
+    try:
+        from coremltools.converters.mil.frontend.torch.ops import _get_inputs
+        from coremltools.converters.mil.frontend.torch.torch_op_registry import (
+            register_torch_op,
+        )
+        from coremltools.converters.mil.mil import Builder as mb
+    except ImportError:
+        return
+
+    if getattr(register_coreml_op_shims, "_done", False):
+        return
+
+    @register_torch_op
+    def multiply(context, node):
+        inputs = _get_inputs(context, node, expected=2)
+        res = mb.mul(x=inputs[0], y=inputs[1], name=node.name)
+        context.add(res)
+
+    register_coreml_op_shims._done = True  # type: ignore[attr-defined]
+
+
+# --- Compact LibriTTS config (mirrors Configs/config_libritts.yml) ------------
+
+
+@dataclass(frozen=True)
+class LibriTTSConfig:
+    sample_rate: int = 24000
+    n_mels: int = 80
+    n_fft: int = 2048
+    hop_length: int = 300
+    win_length: int = 1200
+
+    multispeaker: bool = True
+    dim_in: int = 64
+    hidden_dim: int = 512
+    max_conv_dim: int = 512
+    n_layer: int = 3
+    n_token: int = 178
+    max_dur: int = 50
+    style_dim: int = 128
+    dropout: float = 0.2
+
+    decoder_type: str = "hifigan"
+    resblock_kernel_sizes: Tuple[int, ...] = (3, 7, 11)
+    upsample_rates: Tuple[int, ...] = (10, 5, 3, 2)
+    upsample_initial_channel: int = 512
+    resblock_dilation_sizes: Tuple[Tuple[int, ...], ...] = (
+        (1, 3, 5),
+        (1, 3, 5),
+        (1, 3, 5),
+    )
+    upsample_kernel_sizes: Tuple[int, ...] = (20, 10, 6, 4)
+
+    diffusion_dist_mean: float = -3.0
+    diffusion_dist_std: float = 1.0
+    diffusion_sigma_data: float = 0.2
+
+    transformer_num_layers: int = 3
+    transformer_num_heads: int = 8
+    transformer_head_features: int = 64
+    transformer_multiplier: int = 2
+
+    @property
+    def hop_factor(self) -> int:
+        f = 1
+        for r in self.upsample_rates:
+            f *= r
+        return f
+
+
+# --- Module construction ------------------------------------------------------
+
+
+def _build_modules(cfg: LibriTTSConfig):
+    """Build the inference-relevant nn.Modules. Imports are local to keep the
+    vendor path side-effects scoped."""
+
+    # PL-BERT (HuggingFace AlbertModel). The upstream loader lives in
+    # Utils/PLBERT/util.py — `load_plbert(log_dir)`.
+    sys.path.insert(0, str(PLBERT_DIR))
+    from util import load_plbert  # type: ignore[import-not-found]
+
+    bert = load_plbert(str(PLBERT_DIR))
+
+    # Now bring in upstream model.py
+    from models import (  # type: ignore[import-not-found]
+        ProsodyPredictor,
+        StyleEncoder,
+        TextEncoder,
+    )
+    from Modules.diffusion.modules import (  # type: ignore
+        AttentionBase,
+        StyleTransformer1d,
+    )
+    from Modules.diffusion.diffusion import AudioDiffusionConditional  # type: ignore
+    from Modules.diffusion.sampler import KDiffusion, LogNormalDistribution  # type: ignore
+
+    # `AttentionBase.forward` uses einsum with leading `...` (e.g.
+    # "... n d, ... m d -> ... n m"). coremltools 8.x routes this through
+    # `solve_diagonal_einsum`, which then asks the MIL transpose op to permute
+    # a 4-D tensor with a 5-element perm — fails with "perm should have the
+    # same length as rank(x)". Patch the forward to use plain matmul.
+    from einops import rearrange  # type: ignore
+
+    def _attention_forward_matmul(self, q, k, v):
+        # q, k, v: (b, n, h*d)
+        q = rearrange(q, "b n (h d) -> b h n d", h=self.num_heads)
+        k = rearrange(k, "b n (h d) -> b h n d", h=self.num_heads)
+        v = rearrange(v, "b n (h d) -> b h n d", h=self.num_heads)
+        sim = torch.matmul(q, k.transpose(-1, -2))  # (b, h, n, m)
+        if self.use_rel_pos:
+            sim = sim + self.rel_pos(*sim.shape[-2:])
+        sim = sim * self.scale
+        attn = sim.softmax(dim=-1)
+        out = torch.matmul(attn, v)  # (b, h, n, d)
+        out = rearrange(out, "b h n d -> b n (h d)")
+        return self.to_out(out)
+
+    AttentionBase.forward = _attention_forward_matmul
+
+    # `SineGen._f02sine` (Modules/hifigan.py) uses `F.interpolate(..., mode="linear",
+    # scale_factor=1/300)` which trips coremltools' upsample_linear1d translator
+    # ("recompute_scale_factor=False, align_corners=False with float output size
+    # is not supported"). Set align_corners=True — quality impact is negligible
+    # and CoreML's upsample_bilinear supports this configuration.
+    import numpy as _np
+    from Modules.hifigan import SineGen  # type: ignore
+
+    def _f02sine_align_corners(self, f0_values):
+        rad_values = (f0_values / self.sampling_rate) % 1
+        if not self.flag_for_pulse:
+            rad_values = F.interpolate(
+                rad_values.transpose(1, 2),
+                scale_factor=1.0 / self.upsample_scale,
+                mode="linear",
+                align_corners=True,
+            ).transpose(1, 2)
+            phase = torch.cumsum(rad_values, dim=1) * 2 * _np.pi
+            phase = F.interpolate(
+                phase.transpose(1, 2) * self.upsample_scale,
+                scale_factor=float(self.upsample_scale),
+                mode="linear",
+                align_corners=True,
+            ).transpose(1, 2)
+            sines = torch.sin(phase)
+        else:
+            # Pulse-train branch is never used in inference (flag_for_pulse=False
+            # in Generator). Keep upstream behavior if anyone flips it.
+            sines = SineGen._f02sine_original(self, f0_values)  # type: ignore[attr-defined]
+        return sines
+
+    if not hasattr(SineGen, "_f02sine_original"):
+        SineGen._f02sine_original = SineGen._f02sine  # type: ignore[attr-defined]
+    SineGen._f02sine = _f02sine_align_corners
+
+    if cfg.decoder_type == "hifigan":
+        from Modules.hifigan import Decoder  # type: ignore
+        decoder = Decoder(
+            dim_in=cfg.hidden_dim,
+            style_dim=cfg.style_dim,
+            dim_out=cfg.n_mels,
+            resblock_kernel_sizes=list(cfg.resblock_kernel_sizes),
+            upsample_rates=list(cfg.upsample_rates),
+            upsample_initial_channel=cfg.upsample_initial_channel,
+            resblock_dilation_sizes=[list(d) for d in cfg.resblock_dilation_sizes],
+            upsample_kernel_sizes=list(cfg.upsample_kernel_sizes),
+        )
+    else:
+        raise ValueError(f"Only hifigan decoder is supported here (got {cfg.decoder_type!r}).")
+
+    text_encoder = TextEncoder(
+        channels=cfg.hidden_dim,
+        kernel_size=5,
+        depth=cfg.n_layer,
+        n_symbols=cfg.n_token,
+    )
+    predictor = ProsodyPredictor(
+        style_dim=cfg.style_dim,
+        d_hid=cfg.hidden_dim,
+        nlayers=cfg.n_layer,
+        max_dur=cfg.max_dur,
+        dropout=cfg.dropout,
+    )
+    style_encoder = StyleEncoder(
+        dim_in=cfg.dim_in,
+        style_dim=cfg.style_dim,
+        max_conv_dim=cfg.hidden_dim,
+    )
+    predictor_encoder = StyleEncoder(
+        dim_in=cfg.dim_in,
+        style_dim=cfg.style_dim,
+        max_conv_dim=cfg.hidden_dim,
+    )
+    bert_encoder = nn.Linear(bert.config.hidden_size, cfg.hidden_dim)
+
+    transformer = StyleTransformer1d(
+        channels=cfg.style_dim * 2,
+        context_embedding_features=bert.config.hidden_size,
+        context_features=cfg.style_dim * 2,
+        num_layers=cfg.transformer_num_layers,
+        num_heads=cfg.transformer_num_heads,
+        head_features=cfg.transformer_head_features,
+        multiplier=cfg.transformer_multiplier,
+    )
+    diffusion = AudioDiffusionConditional(
+        in_channels=1,
+        embedding_max_length=bert.config.max_position_embeddings,
+        embedding_features=bert.config.hidden_size,
+        embedding_mask_proba=0.0,
+        channels=cfg.style_dim * 2,
+        context_features=cfg.style_dim * 2,
+    )
+    diffusion.diffusion = KDiffusion(
+        net=diffusion.unet,
+        sigma_distribution=LogNormalDistribution(
+            mean=cfg.diffusion_dist_mean, std=cfg.diffusion_dist_std
+        ),
+        sigma_data=cfg.diffusion_sigma_data,
+        dynamic_threshold=0.0,
+    )
+    diffusion.diffusion.net = transformer
+    diffusion.unet = transformer
+
+    return {
+        "bert": bert,
+        "bert_encoder": bert_encoder,
+        "text_encoder": text_encoder,
+        "predictor": predictor,
+        "style_encoder": style_encoder,
+        "predictor_encoder": predictor_encoder,
+        "decoder": decoder,
+        "diffusion": diffusion,
+    }
+
+
+def load_inference_modules(checkpoint: Path = DEFAULT_CHECKPOINT, cfg: LibriTTSConfig | None = None):
+    """Build modules and load weights from the stripped checkpoint.
+
+    Returns a dict of `nn.Module` in eval() mode on CPU.
+    """
+    cfg = cfg or LibriTTSConfig()
+    modules = _build_modules(cfg)
+
+    if not checkpoint.exists():
+        raise FileNotFoundError(
+            f"Inference checkpoint {checkpoint} not found. "
+            f"Run scripts/00_fetch_weights.py first."
+        )
+    state = torch.load(checkpoint, map_location="cpu", weights_only=False)
+    for name, module in modules.items():
+        sd = state.get(name)
+        if sd is None:
+            print(f"[lib] skip: no state for {name!r}")
+            continue
+        missing, unexpected = module.load_state_dict(sd, strict=False)
+        if missing:
+            print(f"[lib] {name}: {len(missing)} missing keys (e.g. {missing[:3]})")
+        if unexpected:
+            print(f"[lib] {name}: {len(unexpected)} unexpected keys (e.g. {unexpected[:3]})")
+        module.eval()
+
+    return modules, cfg
+
+
+# --- Traceable wrappers -------------------------------------------------------
+#
+# Every wrapper below assumes batch_size == 1 and lengths == full T_tok / T_mel.
+# This is the inference reality (we always pad to a bucket and feed full
+# tensors). Pack/pad and length-mask logic from training is dropped.
+
+
+class TextEncoderTraceable(nn.Module):
+    """`models.TextEncoder` without pack_padded_sequence and without masks."""
+
+    def __init__(self, text_encoder: nn.Module):
+        super().__init__()
+        self.embedding = text_encoder.embedding
+        self.cnn = text_encoder.cnn  # ModuleList of Sequential(Conv1d, LayerNorm, actv, Dropout)
+        self.lstm = text_encoder.lstm
+
+    def forward(self, tokens: torch.Tensor) -> torch.Tensor:
+        # tokens: (1, T_tok) int64
+        x = self.embedding(tokens)             # (1, T_tok, channels)
+        x = x.transpose(1, 2)                  # (1, channels, T_tok)
+        for c in self.cnn:
+            x = c(x)
+        x = x.transpose(1, 2)                  # (1, T_tok, channels)
+        x, _ = self.lstm(x)                    # (1, T_tok, channels)  (bidir, /2 hidden ×2)
+        x = x.transpose(-1, -2)                # (1, channels, T_tok)
+        return x
+
+
+class DurationEncoderTraceable(nn.Module):
+    """`models.DurationEncoder` for batch=1, no masking, no packing."""
+
+    def __init__(self, duration_encoder: nn.Module):
+        super().__init__()
+        self.lstms = duration_encoder.lstms
+        self.d_model = duration_encoder.d_model
+        self.sty_dim = duration_encoder.sty_dim
+
+    def forward(self, x: torch.Tensor, style: torch.Tensor) -> torch.Tensor:
+        # x: (1, hidden_dim, T_tok)  — d_en from bert_encoder.transpose
+        # style: (1, style_dim)
+        # Returns: (1, T_tok, hidden_dim + style_dim)  — same shape as upstream
+        # (look at upstream final transpose: returns x.transpose(-1,-2))
+
+        # Match upstream layout: bring T to front-of-time, expand style.
+        x = x.permute(2, 0, 1)                 # (T_tok, 1, hidden_dim)
+        s = style.expand(x.shape[0], x.shape[1], -1)  # (T_tok, 1, style_dim)
+        x = torch.cat([x, s], axis=-1)         # (T_tok, 1, hidden_dim + style_dim)
+
+        x = x.transpose(0, 1)                  # (1, T_tok, h+s)
+        x = x.transpose(-1, -2)                # (1, h+s, T_tok)
+
+        # Imports here to avoid leaking the vendor path at module import time.
+        from models import AdaLayerNorm  # type: ignore
+
+        for block in self.lstms:
+            if isinstance(block, AdaLayerNorm):
+                x = block(x.transpose(-1, -2), style).transpose(-1, -2)
+                x = torch.cat([x, s.permute(1, 2, 0)], axis=1)  # cat style as channels
+            else:
+                x = x.transpose(-1, -2)        # (1, T, ch)
+                x, _ = block(x)                # direct LSTM, no pack_padded
+                x = x.transpose(-1, -2)        # (1, ch, T)
+
+        return x.transpose(-1, -2)             # (1, T_tok, h+s)
+
+
+class TextPredictorTraceable(nn.Module):
+    """Package A: tokens → (t_en, d_en, d, pred_dur, fixed_embedding).
+
+    Outputs:
+      t_en:             (1, hidden_dim, T_tok)
+      d_en:             (1, hidden_dim, T_tok)  — bert_encoder(bert(tokens)).transpose
+      d:                (1, T_tok, h+s)         — DurationEncoder hidden
+      pred_dur_log:     (1, T_tok, max_dur)     — pre-sigmoid duration logits
+      fixed_embedding:  (1, T_tok, bert_dim)    — for CFG uncond branch in Swift
+    """
+
+    def __init__(self, modules: dict):
+        super().__init__()
+        self.bert = modules["bert"]
+        self.bert_encoder = modules["bert_encoder"]
+        self.text_encoder = TextEncoderTraceable(modules["text_encoder"])
+        predictor = modules["predictor"]
+        self.duration_encoder = DurationEncoderTraceable(predictor.text_encoder)
+        self.lstm = predictor.lstm
+        self.duration_proj = predictor.duration_proj
+        # Hold a ref to the diffusion's fixed_embedding for CFG uncond.
+        self.fixed_embedding = modules["diffusion"].unet.fixed_embedding
+
+    def forward(self, tokens: torch.Tensor, style: torch.Tensor):
+        # tokens: (1, T_tok) int64
+        # style:  (1, style_dim)
+        t_en = self.text_encoder(tokens)                      # (1, h, T)
+
+        # `CustomAlbert.forward` (Utils/PLBERT/util.py) overrides AlbertModel.forward
+        # to return last_hidden_state directly as a Tensor.
+        bert_dur = self.bert(tokens)
+        # bert_dur: (1, T_tok, bert_dim)
+
+        d_en = self.bert_encoder(bert_dur).transpose(-1, -2)  # (1, h, T)
+
+        d = self.duration_encoder(d_en, style)                # (1, T, h+s)
+
+        x, _ = self.lstm(d)                                   # (1, T, h)
+        pred_dur_log = self.duration_proj(x)                  # (1, T, max_dur)
+
+        fixed_embedding = self.fixed_embedding(bert_dur)      # (1, T, bert_dim)
+
+        return t_en, d_en, d, pred_dur_log, fixed_embedding, bert_dur
+
+
+class DiffusionDenoiseTraceable(nn.Module):
+    """Package B: single ADPM2 / Karras denoising step of the style UNet.
+
+    Wraps `KDiffusion.denoise_fn` minus the kwargs plumbing. The sampler loop
+    and CFG combination live in Swift.
+
+    Inputs:
+      x_noisy:   (1, 1, style_dim*2)
+      sigma:     (1,)                   scalar noise level
+      embedding: (1, T_tok, bert_dim)   either real bert_dur or fixed_embedding
+      features:  (1, style_dim*2)       ref_s
+
+    Output:
+      denoised:  (1, 1, style_dim*2)
+    """
+
+    def __init__(self, modules: dict, sigma_data: float):
+        super().__init__()
+        self.transformer = modules["diffusion"].unet  # StyleTransformer1d
+        self.sigma_data = sigma_data
+
+    def forward(
+        self,
+        x_noisy: torch.Tensor,
+        sigma: torch.Tensor,
+        embedding: torch.Tensor,
+        features: torch.Tensor,
+    ) -> torch.Tensor:
+        # KDiffusion.get_scale_weights — inlined for tracing.
+        s = sigma.view(-1, 1, 1)                             # (1,1,1)
+        sd = self.sigma_data
+        c_skip = (sd * sd) / (s * s + sd * sd)
+        c_out = s * sd / torch.sqrt(s * s + sd * sd)
+        c_in = 1.0 / torch.sqrt(s * s + sd * sd)
+        c_noise = torch.log(sigma) * 0.25                    # (1,)
+
+        # StyleTransformer1d.run bypasses the `forward()` kwargs/CFG path.
+        x_pred = self.transformer.run(
+            c_in * x_noisy,
+            c_noise,
+            embedding=embedding,
+            features=features,
+        )
+        return c_skip * x_noisy + c_out * x_pred
+
+
+class F0NEnergyTraceable(nn.Module):
+    """Package C: predictor.F0Ntrain — (en, s) → (F0, N).
+
+    Pure conv + bidirectional LSTM (`predictor.shared`). The shared LSTM has a
+    fixed seq dim (T_mel) so it traces cleanly.
+    """
+
+    def __init__(self, modules: dict):
+        super().__init__()
+        predictor = modules["predictor"]
+        self.shared = predictor.shared
+        self.F0 = predictor.F0
+        self.N = predictor.N
+        self.F0_proj = predictor.F0_proj
+        self.N_proj = predictor.N_proj
+
+    def forward(self, en: torch.Tensor, s: torch.Tensor):
+        # en: (1, hidden_dim + style_dim, T_mel) — upstream feeds
+        #     `d.transpose(-1,-2) @ alignment` where d is the DurationEncoder
+        #     output with channel dim h+s (640 for LibriTTS).
+        # s:  (1, style_dim)
+        x, _ = self.shared(en.transpose(-1, -2))             # (1, T_mel, h)
+
+        F0 = x.transpose(-1, -2)                             # (1, h, T_mel)
+        for block in self.F0:
+            F0 = block(F0, s)
+        F0 = self.F0_proj(F0).squeeze(1)                     # (1, T_mel)
+
+        N = x.transpose(-1, -2)
+        for block in self.N:
+            N = block(N, s)
+        N = self.N_proj(N).squeeze(1)                        # (1, T_mel)
+
+        return F0, N
+
+
+class HifiGanDecoderTraceable(nn.Module):
+    """Package D: HiFi-GAN Decoder.forward but with eval-only branches.
+
+    Identical in eval mode to `Modules.hifigan.Decoder.forward`; we inline it
+    here to drop the `if self.training` branch entirely so the trace is clean.
+    """
+
+    def __init__(self, decoder: nn.Module):
+        super().__init__()
+        self.encode = decoder.encode
+        self.decode = decoder.decode
+        self.F0_conv = decoder.F0_conv
+        self.N_conv = decoder.N_conv
+        self.asr_res = decoder.asr_res
+        self.generator = decoder.generator
+
+    def forward(
+        self,
+        asr: torch.Tensor,
+        F0_curve: torch.Tensor,
+        N: torch.Tensor,
+        s: torch.Tensor,
+    ) -> torch.Tensor:
+        F0 = self.F0_conv(F0_curve.unsqueeze(1))             # (1, 1, T_mel/2)
+        Nc = self.N_conv(N.unsqueeze(1))                      # (1, 1, T_mel/2)
+
+        x = torch.cat([asr, F0, Nc], dim=1)                   # (1, h+2, T_mel/2)
+        x = self.encode(x, s)                                 # (1, 1024, T_mel/2)
+
+        asr_res = self.asr_res(asr)                           # (1, 64, T_mel/2)
+
+        res = True
+        for block in self.decode:
+            if res:
+                x = torch.cat([x, asr_res, F0, Nc], dim=1)
+            x = block(x, s)
+            if block.upsample_type != "none":
+                res = False
+
+        return self.generator(x, s, F0_curve)                 # (1, T_mel * hop_factor)

--- a/models/tts/styletts2/scripts/optimize/measure_diffusion_buckets.py
+++ b/models/tts/styletts2/scripts/optimize/measure_diffusion_buckets.py
@@ -1,0 +1,33 @@
+"""Measure diffusion_step perf across buckets to inform pruning decision."""
+from __future__ import annotations
+import time
+from pathlib import Path
+import numpy as np
+import coremltools as ct
+
+PKG = Path("/Users/kikow/brandon/voicelink/mobius-styletts2/models/tts/styletts2/coreml")
+BUCKETS = (32, 64, 128, 256, 512)
+
+# 5-step ADPM2 = 9 model calls per generation (n*2 - 1)
+# Use 5 calls (one per sigma) as proxy
+N_CALLS = 9
+
+print(f"{'bucket':>8s}  {'1-call':>10s}  {'5-step':>10s}")
+for tb in BUCKETS:
+    m = ct.models.MLModel(str(PKG / f"styletts2_diffusion_step_{tb}.mlpackage"),
+                          compute_units=ct.ComputeUnit.CPU_ONLY)
+    x = np.random.randn(1, 1, 256).astype(np.float32)
+    sigma = np.array([1.5], dtype=np.float32)
+    emb = np.random.randn(1, tb, 768).astype(np.float32)
+    feat = np.random.randn(1, 256).astype(np.float32)
+    inputs = {"x_noisy": x, "sigma": sigma, "embedding": emb, "features": feat}
+
+    # warmup
+    m.predict(inputs)
+    # time
+    t0 = time.time()
+    for _ in range(N_CALLS):
+        m.predict(inputs)
+    dt = (time.time() - t0) / N_CALLS
+
+    print(f"  {tb:>4d}    {dt*1000:>8.1f}ms   {dt*N_CALLS*1000:>8.1f}ms")

--- a/models/tts/styletts2/scripts/optimize/measure_diffusion_buckets.py
+++ b/models/tts/styletts2/scripts/optimize/measure_diffusion_buckets.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import numpy as np
 import coremltools as ct
 
-PKG = Path("/Users/kikow/brandon/voicelink/mobius-styletts2/models/tts/styletts2/coreml")
+PKG = Path(__file__).resolve().parents[2] / "coreml"
 BUCKETS = (32, 64, 128, 256, 512)
 
 # 5-step ADPM2 = 9 model calls per generation (n*2 - 1)

--- a/models/tts/styletts2/scripts/optimize/quantize_text_predictor_int8.py
+++ b/models/tts/styletts2/scripts/optimize/quantize_text_predictor_int8.py
@@ -1,0 +1,43 @@
+"""Quantize all 5 text_predictor buckets to int8."""
+import time
+from pathlib import Path
+import coremltools as ct
+from coremltools.optimize.coreml import (
+    OpLinearQuantizerConfig,
+    OptimizationConfig,
+    linear_quantize_weights,
+)
+
+PKG = Path("/Users/kikow/brandon/voicelink/mobius-styletts2/models/tts/styletts2/coreml")
+
+op_cfg = OpLinearQuantizerConfig(
+    mode="LINEAR_SYMMETRIC",
+    dtype="int8",
+    granularity="per_channel",
+    weight_threshold=200_000,
+)
+config = OptimizationConfig(global_config=op_cfg)
+
+def du(p):
+    return sum(f.stat().st_size for f in p.rglob("*") if f.is_file()) / 1024 / 1024
+
+total_fp16 = total_int8 = 0
+for tok in (32, 64, 128, 256, 512):
+    src = PKG / f"styletts2_text_predictor_{tok}.mlpackage"
+    dst = PKG / f"styletts2_text_predictor_{tok}_int8.mlpackage"
+    print(f"[{tok}] loading …")
+    t0 = time.time()
+    m = ct.models.MLModel(str(src), compute_units=ct.ComputeUnit.CPU_ONLY)
+    print(f"  loaded ({time.time()-t0:.1f}s); quantizing …")
+    t0 = time.time()
+    mq = linear_quantize_weights(m, config)
+    print(f"  quantized ({time.time()-t0:.1f}s); saving …")
+    mq.save(str(dst))
+    fp16 = du(src); int8 = du(dst)
+    total_fp16 += fp16; total_int8 += int8
+    print(f"  fp16={fp16:.1f} MB  int8={int8:.1f} MB  reduction={1-int8/fp16:.1%}")
+
+print()
+print(f"TOTAL fp16: {total_fp16:.1f} MB")
+print(f"TOTAL int8: {total_int8:.1f} MB")
+print(f"saved: {total_fp16-total_int8:.1f} MB ({1-total_int8/total_fp16:.1%})")

--- a/models/tts/styletts2/scripts/optimize/quantize_text_predictor_int8.py
+++ b/models/tts/styletts2/scripts/optimize/quantize_text_predictor_int8.py
@@ -8,7 +8,7 @@ from coremltools.optimize.coreml import (
     linear_quantize_weights,
 )
 
-PKG = Path("/Users/kikow/brandon/voicelink/mobius-styletts2/models/tts/styletts2/coreml")
+PKG = Path(__file__).resolve().parents[2] / "coreml"
 
 op_cfg = OpLinearQuantizerConfig(
     mode="LINEAR_SYMMETRIC",

--- a/models/tts/styletts2/uv.lock
+++ b/models/tts/styletts2/uv.lock
@@ -1,0 +1,1103 @@
+version = 1
+requires-python = ">=3.10, <3.13"
+resolution-markers = [
+    "python_full_version >= '3.11' and sys_platform != 'darwin'",
+    "python_full_version >= '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548 },
+]
+
+[[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845 },
+]
+
+[[package]]
+name = "cattrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/ec/ba18945e7d6e55a58364d9fb2e46049c1c2998b3d805f19b703f14e81057/cattrs-26.1.0.tar.gz", hash = "sha256:fa239e0f0ec0715ba34852ce813986dfed1e12117e209b816ab87401271cdd40", size = 495672 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl", hash = "sha256:d1e0804c42639494d469d08d4f26d6b9de9b8ab26b446db7b5f8c2e97f7c3096", size = 73054 },
+]
+
+[[package]]
+name = "certifi"
+version = "2022.12.7"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+wheels = [
+    { url = "https://download.pytorch.org/whl/certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d7/516d984057745a6cd96575eea814fe1edd6646ee6efd552fb7b0921dec83/cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44", size = 184283 },
+    { url = "https://files.pythonhosted.org/packages/9e/84/ad6a0b408daa859246f57c03efd28e5dd1b33c21737c2db84cae8c237aa5/cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49", size = 180504 },
+    { url = "https://files.pythonhosted.org/packages/50/bd/b1a6362b80628111e6653c961f987faa55262b4002fcec42308cad1db680/cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c", size = 208811 },
+    { url = "https://files.pythonhosted.org/packages/4f/27/6933a8b2562d7bd1fb595074cf99cc81fc3789f6a6c05cdabb46284a3188/cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb", size = 216402 },
+    { url = "https://files.pythonhosted.org/packages/05/eb/b86f2a2645b62adcfff53b0dd97e8dfafb5c8aa864bd0d9a2c2049a0d551/cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0", size = 203217 },
+    { url = "https://files.pythonhosted.org/packages/9f/e0/6cbe77a53acf5acc7c08cc186c9928864bd7c005f9efd0d126884858a5fe/cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4", size = 203079 },
+    { url = "https://files.pythonhosted.org/packages/98/29/9b366e70e243eb3d14a5cb488dfd3a0b6b2f1fb001a203f653b93ccfac88/cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453", size = 216475 },
+    { url = "https://files.pythonhosted.org/packages/21/7a/13b24e70d2f90a322f2900c5d8e1f14fa7e2a6b3332b7309ba7b2ba51a5a/cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495", size = 218829 },
+    { url = "https://files.pythonhosted.org/packages/60/99/c9dc110974c59cc981b1f5b66e1d8af8af764e00f0293266824d9c4254bc/cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5", size = 211211 },
+    { url = "https://files.pythonhosted.org/packages/49/72/ff2d12dbf21aca1b32a40ed792ee6b40f6dc3a9cf1644bd7ef6e95e0ac5e/cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb", size = 218036 },
+    { url = "https://files.pythonhosted.org/packages/e2/cc/027d7fb82e58c48ea717149b03bcadcbdc293553edb283af792bd4bcbb3f/cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a", size = 172184 },
+    { url = "https://files.pythonhosted.org/packages/33/fa/072dd15ae27fbb4e06b437eb6e944e75b068deb09e2a2826039e49ee2045/cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739", size = 182790 },
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344 },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560 },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613 },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476 },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374 },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597 },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574 },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971 },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972 },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078 },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076 },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820 },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635 },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271 },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048 },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529 },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097 },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983 },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519 },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572 },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963 },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361 },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932 },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557 },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762 },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "2.1.1"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+wheels = [
+    { url = "https://download.pytorch.org/whl/charset_normalizer-2.1.1-py3-none-any.whl", hash = "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+wheels = [
+    { url = "https://download.pytorch.org/whl/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6" },
+]
+
+[[package]]
+name = "coremltools"
+version = "8.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "pyaml" },
+    { name = "sympy" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/f1/322d8cb29c59b8710375927a6d776887ed4c6caafd036cf4fbe14dcdb767/coremltools-8.3.0.tar.gz", hash = "sha256:c95a6051606b71273d669b107b5f32d3191f595e6821b8db04baf49d52d0704f", size = 1642701 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/9e/b9070c8d44c7d5e3a552d5b19ebe07fd9814b72ce7be452138596bdcbc18/coremltools-8.3.0-cp310-none-macosx_10_15_x86_64.whl", hash = "sha256:730831927cde3ba39ae6f80b72c5fbff8820393f2f97ec1c98ab33ec08094c4e", size = 2767146 },
+    { url = "https://files.pythonhosted.org/packages/63/ad/6293617987fc4de90030d0556ede0fcb7fc0c17e9907146e18f400efe482/coremltools-8.3.0-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:5f95af47531fb2f01a501ae5fad01e7dfb1cc0b70b035fbed6d788201cbc9a56", size = 2740012 },
+    { url = "https://files.pythonhosted.org/packages/c4/c9/f602c2a7861a9e8a2555a083d9558d37d8811515bacd597eb3b40ba7757d/coremltools-8.3.0-cp310-none-manylinux1_x86_64.whl", hash = "sha256:e505c2b89b5bd1b1425466a8d45cc6edd75c81b0c3834403992a575a1c134c34", size = 2292024 },
+    { url = "https://files.pythonhosted.org/packages/72/a6/31dc762e0317d26b2d21919e12c42644ecab8401ff2aa6f00215156a45ee/coremltools-8.3.0-cp311-none-macosx_10_15_x86_64.whl", hash = "sha256:59ff68ec62bf2c0421041142117e37ef679f46e6304653aea64cbe8a39a5f9bc", size = 2770927 },
+    { url = "https://files.pythonhosted.org/packages/69/32/847810ade6b7105fcf810188f41dc4bb25e2278f505f8a08185bd8787cbb/coremltools-8.3.0-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:5f843f5a6be740d84eb7c80c49766da0b9bd67e86a9cb1dbfce838ab5366feb3", size = 2743785 },
+    { url = "https://files.pythonhosted.org/packages/36/9c/a6fbc66e300e176f94ab6f90530d33c703868126572fb9119cc952b8ecc6/coremltools-8.3.0-cp311-none-manylinux1_x86_64.whl", hash = "sha256:3d6d5828688347b5f6e31f1ce522b5df5733246611dbcb09fbc94687ff0fc16a", size = 2293270 },
+    { url = "https://files.pythonhosted.org/packages/94/74/0fea61f7644dda226fe8da364c9e68df3f1f7c6f59e6e8646215581af3d0/coremltools-8.3.0-cp312-none-macosx_10_15_x86_64.whl", hash = "sha256:2bfb57173a9fcbeb1f5bd3bfc90169c817ee04882564eafb79deafa494f96523", size = 2770175 },
+    { url = "https://files.pythonhosted.org/packages/56/2b/a06357e7881bacc92a4d125064202bf48acfe63368c781f49d688bca3b51/coremltools-8.3.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:e8a70ca3b34676cbcb61f70e1192593062eb85a9a64e29e03268d6f280b2c86e", size = 2740828 },
+    { url = "https://files.pythonhosted.org/packages/a2/52/6c15580d9049930dc6319d70cc065622e569afc1307d177bf45cb9f82076/coremltools-8.3.0-cp312-none-manylinux1_x86_64.whl", hash = "sha256:36ee21f1ab35bd45500ce006b366d45f4210a86882283d6cf2e603faeaaf791c", size = 2292484 },
+]
+
+[[package]]
+name = "csvw"
+version = "3.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "babel" },
+    { name = "isodate" },
+    { name = "jsonschema" },
+    { name = "language-tags" },
+    { name = "python-dateutil" },
+    { name = "rdflib" },
+    { name = "requests" },
+    { name = "rfc3986" },
+    { name = "termcolor" },
+    { name = "uritemplate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/90/64efac40e52949079c2b4030167ee68ec52cf061f11e368ee1a82e410670/csvw-3.7.0.tar.gz", hash = "sha256:869b5c761481e52c01a99fb4749b278a4b8b0db4e0fa1965a33a3441c703465b", size = 74789 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/cb/19e8e582fc164db200c18078bdbdcc60c012cb83c7f02ea8e876bc0b1adf/csvw-3.7.0-py2.py3-none-any.whl", hash = "sha256:21b88db50a35e940d4b5cdd8f3a8084493ad7f1bb1657ed7323aad977359940e", size = 60685 },
+]
+
+[[package]]
+name = "dlinfo"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/8e/8f2f94cd40af1b51e8e371a83b385d622170d42f98776441a6118f4dd682/dlinfo-2.0.0.tar.gz", hash = "sha256:88a2bc04f51d01bc604cdc9eb1c3cc0bde89057532ca6a3e71a41f6235433e17", size = 12727 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/90/022c79d6e5e6f843268c10b84d4a021ee3afba0621d3c176d3ff2024bfc8/dlinfo-2.0.0-py3-none-any.whl", hash = "sha256:b32cc18e3ea67c0ca9ca409e5b41eed863bd1363dbc9dd3de90fedf11b61e7bc", size = 3654 },
+]
+
+[[package]]
+name = "einops"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/77/850bef8d72ffb9219f0b1aac23fbc1bf7d038ee6ea666f331fa273031aa2/einops-0.8.2.tar.gz", hash = "sha256:609da665570e5e265e27283aab09e7f279ade90c4f01bcfca111f3d3e13f2827", size = 56261 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl", hash = "sha256:54058201ac7087911181bfec4af6091bb59380360f069276601256a76af08193", size = 65638 },
+]
+
+[[package]]
+name = "einops-exts"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "einops" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/cc/f2b03b24894faaaa425cf46508e6b1f449d908841f61aeb7c14f0b18a3f3/einops-exts-0.0.4.tar.gz", hash = "sha256:616f145b3411f8e9e3be5da5c968bbe372e55c249de11faa909c7a4b74580a6c", size = 3548 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/01/8da8dd078b354a89602a875d310a0d725dad92b5b4d61069576e0a0e02e4/einops_exts-0.0.4-py3-none-any.whl", hash = "sha256:6d310a4c858e459ebff8288580f90255d354cfa3bde22a53b59baae64b48cb95", size = 3925 },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740 },
+]
+
+[[package]]
+name = "filelock"
+version = "3.25.2"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.2.0"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/92/ec9ad04d0b5728dca387a45af7bc98fbb0d73b2118759f5f6038b61a57e8/hf_xet-1.4.3.tar.gz", hash = "sha256:8ddedb73c8c08928c793df2f3401ec26f95be7f7e516a7bee2fbb546f6676113", size = 670477 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/9f/9c23e4a447b8f83120798f9279d0297a4d1360bdbf59ef49ebec78fe2545/hf_xet-1.4.3-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d0da85329eaf196e03e90b84c2d0aca53bd4573d097a75f99609e80775f98025", size = 3805048 },
+    { url = "https://files.pythonhosted.org/packages/0b/f8/7aacb8e5f4a7899d39c787b5984e912e6c18b11be136ef13947d7a66d265/hf_xet-1.4.3-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e23717ce4186b265f69afa66e6f0069fe7efbf331546f5c313d00e123dc84583", size = 3562178 },
+    { url = "https://files.pythonhosted.org/packages/df/9a/a24b26dc8a65f0ecc0fe5be981a19e61e7ca963b85e062c083f3a9100529/hf_xet-1.4.3-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc360b70c815bf340ed56c7b8c63aacf11762a4b099b2fe2c9bd6d6068668c08", size = 4212320 },
+    { url = "https://files.pythonhosted.org/packages/53/60/46d493db155d2ee2801b71fb1b0fd67696359047fdd8caee2c914cc50c79/hf_xet-1.4.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:39f2d2e9654cd9b4319885733993807aab6de9dfbd34c42f0b78338d6617421f", size = 3991546 },
+    { url = "https://files.pythonhosted.org/packages/bc/f5/067363e1c96c6b17256910830d1b54099d06287e10f4ec6ec4e7e08371fc/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:49ad8a8cead2b56051aa84d7fce3e1335efe68df3cf6c058f22a65513885baac", size = 4193200 },
+    { url = "https://files.pythonhosted.org/packages/42/4b/53951592882d9c23080c7644542fda34a3813104e9e11fa1a7d82d419cb8/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7716d62015477a70ea272d2d68cd7cad140f61c52ee452e133e139abfe2c17ba", size = 4429392 },
+    { url = "https://files.pythonhosted.org/packages/8a/21/75a6c175b4e79662ad8e62f46a40ce341d8d6b206b06b4320d07d55b188c/hf_xet-1.4.3-cp37-abi3-win_amd64.whl", hash = "sha256:6b591fcad34e272a5b02607485e4f2a1334aebf1bc6d16ce8eb1eb8978ac2021", size = 3677359 },
+    { url = "https://files.pythonhosted.org/packages/8a/7c/44314ecd0e89f8b2b51c9d9e5e7a60a9c1c82024ac471d415860557d3cd8/hf_xet-1.4.3-cp37-abi3-win_arm64.whl", hash = "sha256:7c2c7e20bcfcc946dc67187c203463f5e932e395845d098cc2a93f5b67ca0b47", size = 3533664 },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "0.36.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395 },
+]
+
+[[package]]
+name = "idna"
+version = "3.4"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+wheels = [
+    { url = "https://download.pytorch.org/whl/idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2" },
+]
+
+[[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320 },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+dependencies = [
+    { name = "markupsafe" },
+]
+wheels = [
+    { url = "https://download.pytorch.org/whl/jinja2-3.1.6-py3-none-any.whl" },
+]
+
+[[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071 },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630 },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437 },
+]
+
+[[package]]
+name = "language-tags"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/7e/b6a0efe4fee11e9742c1baaedf7c574084238a70b03c1d8eb2761383848f/language_tags-1.2.0.tar.gz", hash = "sha256:e934acba3e3dc85f867703eca421847a9ab7b7679b11b5d5cfd096febbf8bde6", size = 207901 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/42/327554649ed2dd5ce59d3f5da176c7be20f9352c7c6c51597293660b7b08/language_tags-1.2.0-py3-none-any.whl", hash = "sha256:d815604622242fdfbbfd747b40c31213617fd03734a267f2e39ee4bd73c88722", size = 213449 },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+wheels = [
+    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl" },
+    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl" },
+    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp310-cp310-win_amd64.whl" },
+    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl" },
+    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl" },
+    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp311-cp311-win_amd64.whl" },
+    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl" },
+    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl" },
+    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp312-cp312-win_amd64.whl" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c" },
+]
+
+[[package]]
+name = "munch"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/2b/45098135b5f9f13221820d90f9e0516e11a2a0f55012c13b081d202b782a/munch-4.0.0.tar.gz", hash = "sha256:542cb151461263216a4e37c3fd9afc425feeaf38aaa3025cd2a981fadb422235", size = 19089 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/b3/7c69b37f03260a061883bec0e7b05be7117c1b1c85f5212c72c8c2bc3c8c/munch-4.0.0-py2.py3-none-any.whl", hash = "sha256:71033c45db9fb677a0b7eb517a4ce70ae09258490e419b0e7f00d1e386ecb1b4", size = 9950 },
+]
+
+[[package]]
+name = "networkx"
+version = "3.4.2"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.11' and sys_platform != 'darwin'",
+    "python_full_version >= '3.11' and sys_platform == 'darwin'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762" },
+]
+
+[[package]]
+name = "numpy"
+version = "1.26.4"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/94/ace0fdea5241a27d13543ee117cbc65868e82213fb31a8eb7fe9ff23f313/numpy-1.26.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0" },
+    { url = "https://files.pythonhosted.org/packages/20/f7/b24208eba89f9d1b58c1668bc6c8c4fd472b20c45573cb767f59d49fb0f6/numpy-1.26.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a" },
+    { url = "https://files.pythonhosted.org/packages/fc/a5/4beee6488160798683eed5bdb7eead455892c3b4e1f78d79d8d3f3b084ac/numpy-1.26.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4" },
+    { url = "https://files.pythonhosted.org/packages/4b/d7/ecf66c1cd12dc28b4040b15ab4d17b773b87fa9d29ca16125de01adb36cd/numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f" },
+    { url = "https://files.pythonhosted.org/packages/24/03/6f229fe3187546435c4f6f89f6d26c129d4f5bed40552899fcf1f0bf9e50/numpy-1.26.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a" },
+    { url = "https://files.pythonhosted.org/packages/39/fe/39ada9b094f01f5a35486577c848fe274e374bbf8d8f472e1423a0bbd26d/numpy-1.26.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2" },
+    { url = "https://files.pythonhosted.org/packages/d5/ef/6ad11d51197aad206a9ad2286dc1aac6a378059e06e8cf22cd08ed4f20dc/numpy-1.26.4-cp310-cp310-win32.whl", hash = "sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07" },
+    { url = "https://files.pythonhosted.org/packages/19/77/538f202862b9183f54108557bfda67e17603fc560c384559e769321c9d92/numpy-1.26.4-cp310-cp310-win_amd64.whl", hash = "sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5" },
+    { url = "https://files.pythonhosted.org/packages/11/57/baae43d14fe163fa0e4c47f307b6b2511ab8d7d30177c491960504252053/numpy-1.26.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71" },
+    { url = "https://files.pythonhosted.org/packages/1a/2e/151484f49fd03944c4a3ad9c418ed193cfd02724e138ac8a9505d056c582/numpy-1.26.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef" },
+    { url = "https://files.pythonhosted.org/packages/79/ae/7e5b85136806f9dadf4878bf73cf223fe5c2636818ba3ab1c585d0403164/numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e" },
+    { url = "https://files.pythonhosted.org/packages/3a/d0/edc009c27b406c4f9cbc79274d6e46d634d139075492ad055e3d68445925/numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5" },
+    { url = "https://files.pythonhosted.org/packages/09/bf/2b1aaf8f525f2923ff6cfcf134ae5e750e279ac65ebf386c75a0cf6da06a/numpy-1.26.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a" },
+    { url = "https://files.pythonhosted.org/packages/df/a0/4e0f14d847cfc2a633a1c8621d00724f3206cfeddeb66d35698c4e2cf3d2/numpy-1.26.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a" },
+    { url = "https://files.pythonhosted.org/packages/d2/b7/a734c733286e10a7f1a8ad1ae8c90f2d33bf604a96548e0a4a3a6739b468/numpy-1.26.4-cp311-cp311-win32.whl", hash = "sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20" },
+    { url = "https://files.pythonhosted.org/packages/3f/6b/5610004206cf7f8e7ad91c5a85a8c71b2f2f8051a0c0c4d5916b76d6cbb2/numpy-1.26.4-cp311-cp311-win_amd64.whl", hash = "sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2" },
+    { url = "https://files.pythonhosted.org/packages/95/12/8f2020a8e8b8383ac0177dc9570aad031a3beb12e38847f7129bacd96228/numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218" },
+    { url = "https://files.pythonhosted.org/packages/75/5b/ca6c8bd14007e5ca171c7c03102d17b4f4e0ceb53957e8c44343a9546dcc/numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b" },
+    { url = "https://files.pythonhosted.org/packages/79/f8/97f10e6755e2a7d027ca783f63044d5b1bc1ae7acb12afe6a9b4286eac17/numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b" },
+    { url = "https://files.pythonhosted.org/packages/0f/50/de23fde84e45f5c4fda2488c759b69990fd4512387a8632860f3ac9cd225/numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed" },
+    { url = "https://files.pythonhosted.org/packages/4c/0c/9c603826b6465e82591e05ca230dfc13376da512b25ccd0894709b054ed0/numpy-1.26.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a" },
+    { url = "https://files.pythonhosted.org/packages/76/8c/2ba3902e1a0fc1c74962ea9bb33a534bb05984ad7ff9515bf8d07527cadd/numpy-1.26.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0" },
+    { url = "https://files.pythonhosted.org/packages/28/4a/46d9e65106879492374999e76eb85f87b15328e06bd1550668f79f7b18c6/numpy-1.26.4-cp312-cp312-win32.whl", hash = "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/86f24451c2d530c88daf997cb8d6ac622c1d40d19f5a031ed68a4b73a374/numpy-1.26.4-cp312-cp312-win_amd64.whl", hash = "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818" },
+]
+
+[[package]]
+name = "packaging"
+version = "24.1"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+wheels = [
+    { url = "https://download.pytorch.org/whl/packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124" },
+]
+
+[[package]]
+name = "phonemizer"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "dlinfo" },
+    { name = "joblib" },
+    { name = "segments" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/ff/3574c55a71b42ad6944a5bf0a7d59f0251ea2ba47e51a5c4005e32e9145c/phonemizer-3.3.0.tar.gz", hash = "sha256:5e0c38122effe0b331a24e674aff256874ece169d70a9cf1120337b56f8e3d0c", size = 88564 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/23/e8d67c2052e132181c4c9027c2d8ed9e37e8acb27acfc13ed2d0c41ed850/phonemizer-3.3.0-py3-none-any.whl", hash = "sha256:17afaa98691fe73b025dd8d8727b0e67cc376c5e7ee27590853e457fb3f43602", size = 103800 },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.34.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/6b/a0e95cad1ad7cc3f2c6821fcab91671bd5b78bd42afb357bb4765f29bc41/protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280", size = 454708 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/11/3325d41e6ee15bf1125654301211247b042563bcc898784351252549a8ad/protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7", size = 429247 },
+    { url = "https://files.pythonhosted.org/packages/eb/9d/aa69df2724ff63efa6f72307b483ce0827f4347cc6d6df24b59e26659fef/protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b", size = 325753 },
+    { url = "https://files.pythonhosted.org/packages/92/e8/d174c91fd48e50101943f042b09af9029064810b734e4160bbe282fa1caa/protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a", size = 340198 },
+    { url = "https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4", size = 324267 },
+    { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628 },
+    { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901 },
+    { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715 },
+]
+
+[[package]]
+name = "pyaml"
+version = "26.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/fb/2b9590512a9d7763620d87171c7531d5295678ce96e57393614b91da8998/pyaml-26.2.1.tar.gz", hash = "sha256:489dd82997235d4cfcf76a6287fce2f075487d77a6567c271e8d790583690c68", size = 30653 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/f3/1f8651f23101e6fae41d0d504414c9722b0140bf0fc6acf87ac52e18aa41/pyaml-26.2.1-py3-none-any.whl", hash = "sha256:6261c2f0a2f33245286c794ad6ec234be33a73d2b05427079fd343e2812a87cf", size = 27211 },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172 },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781 },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227 },
+    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019 },
+    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646 },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793 },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293 },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872 },
+    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828 },
+    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415 },
+    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561 },
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826 },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577 },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556 },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114 },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638 },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463 },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986 },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543 },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763 },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063 },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973 },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116 },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011 },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870 },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089 },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181 },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658 },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003 },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344 },
+]
+
+[[package]]
+name = "rdflib"
+version = "7.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "isodate", marker = "python_full_version < '3.11'" },
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/f5/18bb77b7af9526add0c727a3b2048959847dc5fb030913e2918bf384fec3/rdflib-7.6.0.tar.gz", hash = "sha256:6c831288d5e4a5a7ece85d0ccde9877d512a3d0f02d7c06455d00d6d0ea379df", size = 4943826 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/c2/6604a71269e0c1bd75656d5a001432d16f2cc5b8c057140ec797155c295e/rdflib-7.6.0-py3-none-any.whl", hash = "sha256:30c0a3ebf4c0e09215f066be7246794b6492e054e782d7ac2a34c9f70a15e0dd", size = 615416 },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766 },
+]
+
+[[package]]
+name = "regex"
+version = "2026.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/0e/3a246dbf05666918bd3664d9d787f84a9108f6f43cc953a077e4a7dfdb7e/regex-2026.4.4.tar.gz", hash = "sha256:e08270659717f6973523ce3afbafa53515c4dc5dcad637dc215b6fd50f689423", size = 416000 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/59/fd98f8fd54b3feaa76a855324c676c17668c5a1121ec91b7ec96b01bf865/regex-2026.4.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:74fa82dcc8143386c7c0392e18032009d1db715c25f4ba22d23dc2e04d02a20f", size = 489403 },
+    { url = "https://files.pythonhosted.org/packages/6c/64/d0f222f68e3579d50babf0e4fcc9c9639ef0587fecc00b15e1e46bfc32fa/regex-2026.4.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a85b620a388d6c9caa12189233109e236b3da3deffe4ff11b84ae84e218a274f", size = 291208 },
+    { url = "https://files.pythonhosted.org/packages/16/7f/3fab9709b0b0060ba81a04b8a107b34147cd14b9c5551b772154d6505504/regex-2026.4.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2895506ebe32cc63eeed8f80e6eae453171cfccccab35b70dc3129abec35a5b8", size = 289214 },
+    { url = "https://files.pythonhosted.org/packages/14/bc/f5dcf04fd462139dcd75495c02eee22032ef741cfa151386a39c3f5fc9b5/regex-2026.4.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6780f008ee81381c737634e75c24e5a6569cc883c4f8e37a37917ee79efcafd9", size = 785505 },
+    { url = "https://files.pythonhosted.org/packages/37/36/8a906e216d5b4de7ec3788c1d589b45db40c1c9580cd7b326835cfc976d4/regex-2026.4.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:88e9b048345c613f253bea4645b2fe7e579782b82cac99b1daad81e29cc2ed8e", size = 852129 },
+    { url = "https://files.pythonhosted.org/packages/a5/bb/bad2d79be0917a6ef31f5e0f161d9265cb56fd90a3ae1d2e8d991882a48b/regex-2026.4.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:be061028481186ba62a0f4c5f1cc1e3d5ab8bce70c89236ebe01023883bc903b", size = 899578 },
+    { url = "https://files.pythonhosted.org/packages/1a/b9/7cd0ceb58cd99c70806241636640ae15b4a3fe62e22e9b99afa67a0d7965/regex-2026.4.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d2228c02b368d69b724c36e96d3d1da721561fb9cc7faa373d7bf65e07d75cb5", size = 793634 },
+    { url = "https://files.pythonhosted.org/packages/2c/fb/c58e3ea40ed183806ccbac05c29a3e8c2f88c1d3a66ed27860d5cad7c62d/regex-2026.4.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0540e5b733618a2f84e9cb3e812c8afa82e151ca8e19cf6c4e95c5a65198236f", size = 786210 },
+    { url = "https://files.pythonhosted.org/packages/54/a9/53790fc7a6c948a7be2bc7214fd9cabdd0d1ba561b0f401c91f4ff0357f0/regex-2026.4.4-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cf9b1b2e692d4877880388934ac746c99552ce6bf40792a767fd42c8c99f136d", size = 769930 },
+    { url = "https://files.pythonhosted.org/packages/e3/3c/29ca44729191c79f5476538cd0fa04fa2553b3c45508519ecea4c7afa8f6/regex-2026.4.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:011bb48bffc1b46553ac704c975b3348717f4e4aa7a67522b51906f99da1820c", size = 774892 },
+    { url = "https://files.pythonhosted.org/packages/3e/db/6ae74ef8a4cfead341c367e4eed45f71fb1aaba35827a775eed4f1ba4f74/regex-2026.4.4-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:8512fcdb43f1bf18582698a478b5ab73f9c1667a5b7548761329ef410cd0a760", size = 848816 },
+    { url = "https://files.pythonhosted.org/packages/53/9a/f7f2c1c6b610d7c6de1c3dc5951effd92c324b1fde761af2044b4721020f/regex-2026.4.4-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:867bddc63109a0276f5a31999e4c8e0eb7bbbad7d6166e28d969a2c1afeb97f9", size = 758363 },
+    { url = "https://files.pythonhosted.org/packages/dd/55/e5386d393bbf8b43c8b084703a46d635e7b2bdc6e0f5909a2619ea1125f1/regex-2026.4.4-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:1b9a00b83f3a40e09859c78920571dcb83293c8004079653dd22ec14bbfa98c7", size = 837122 },
+    { url = "https://files.pythonhosted.org/packages/01/da/cc78710ea2e60b10bacfcc9beb18c67514200ab03597b3b2b319995785c2/regex-2026.4.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e355be718caf838aa089870259cf1776dc2a4aa980514af9d02c59544d9a8b22", size = 782140 },
+    { url = "https://files.pythonhosted.org/packages/a2/5f/c7bcba41529105d6c2ca7080ecab7184cd00bee2e1ad1fdea80e618704ea/regex-2026.4.4-cp310-cp310-win32.whl", hash = "sha256:33bfda9684646d323414df7abe5692c61d297dbb0530b28ec66442e768813c59", size = 266225 },
+    { url = "https://files.pythonhosted.org/packages/eb/26/a745729c2c49354ec4f4bce168f29da932ca01b4758227686cc16c7dde1b/regex-2026.4.4-cp310-cp310-win_amd64.whl", hash = "sha256:0709f22a56798457ae317bcce42aacee33c680068a8f14097430d9f9ba364bee", size = 278393 },
+    { url = "https://files.pythonhosted.org/packages/87/8b/4327eeb9dbb4b098ebecaf02e9f82b79b6077beeb54c43d9a0660cf7c44c/regex-2026.4.4-cp310-cp310-win_arm64.whl", hash = "sha256:ee9627de8587c1a22201cb16d0296ab92b4df5cdcb5349f4e9744d61db7c7c98", size = 270470 },
+    { url = "https://files.pythonhosted.org/packages/e0/7a/617356cbecdb452812a5d42f720d6d5096b360d4a4c1073af700ea140ad2/regex-2026.4.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b4c36a85b00fadb85db9d9e90144af0a980e1a3d2ef9cd0f8a5bef88054657c6", size = 489415 },
+    { url = "https://files.pythonhosted.org/packages/20/e6/bf057227144d02e3ba758b66649e87531d744dda5f3254f48660f18ae9d8/regex-2026.4.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:dcb5453ecf9cd58b562967badd1edbf092b0588a3af9e32ee3d05c985077ce87", size = 291205 },
+    { url = "https://files.pythonhosted.org/packages/eb/3b/637181b787dd1a820ba1c712cee2b4144cd84a32dc776ca067b12b2d70c8/regex-2026.4.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6aa809ed4dc3706cc38594d67e641601bd2f36d5555b2780ff074edfcb136cf8", size = 289225 },
+    { url = "https://files.pythonhosted.org/packages/05/21/bac05d806ed02cd4b39d9c8e5b5f9a2998c94c3a351b7792e80671fa5315/regex-2026.4.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:33424f5188a7db12958246a54f59a435b6cb62c5cf9c8d71f7cc49475a5fdada", size = 792434 },
+    { url = "https://files.pythonhosted.org/packages/d9/17/c65d1d8ae90b772d5758eb4014e1e011bb2db353fc4455432e6cc9100df7/regex-2026.4.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d346fccdde28abba117cc9edc696b9518c3307fbfcb689e549d9b5979018c6d", size = 861730 },
+    { url = "https://files.pythonhosted.org/packages/ad/64/933321aa082a2c6ee2785f22776143ba89840189c20d3b6b1d12b6aae16b/regex-2026.4.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:415a994b536440f5011aa77e50a4274d15da3245e876e5c7f19da349caaedd87", size = 906495 },
+    { url = "https://files.pythonhosted.org/packages/01/ea/4c8d306e9c36ac22417336b1e02e7b358152c34dc379673f2d331143725f/regex-2026.4.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21e5eb86179b4c67b5759d452ea7c48eb135cd93308e7a260aa489ed2eb423a4", size = 799810 },
+    { url = "https://files.pythonhosted.org/packages/29/ce/7605048f00e1379eba89d610c7d644d8f695dc9b26d3b6ecfa3132b872ff/regex-2026.4.4-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:312ec9dd1ae7d96abd8c5a36a552b2139931914407d26fba723f9e53c8186f86", size = 774242 },
+    { url = "https://files.pythonhosted.org/packages/e9/77/283e0d5023fde22cd9e86190d6d9beb21590a452b195ffe00274de470691/regex-2026.4.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a0d2b28aa1354c7cd7f71b7658c4326f7facac106edd7f40eda984424229fd59", size = 781257 },
+    { url = "https://files.pythonhosted.org/packages/8b/fb/7f3b772be101373c8626ed34c5d727dcbb8abd42a7b1219bc25fd9a3cc04/regex-2026.4.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:349d7310eddff40429a099c08d995c6d4a4bfaf3ff40bd3b5e5cb5a5a3c7d453", size = 854490 },
+    { url = "https://files.pythonhosted.org/packages/85/30/56547b80f34f4dd2986e1cdd63b1712932f63b6c4ce2f79c50a6cd79d1c2/regex-2026.4.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:e7ab63e9fe45a9ec3417509e18116b367e89c9ceb6219222a3396fa30b147f80", size = 763544 },
+    { url = "https://files.pythonhosted.org/packages/ac/2f/ce060fdfea8eff34a8997603532e44cdb7d1f35e3bc253612a8707a90538/regex-2026.4.4-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:fe896e07a5a2462308297e515c0054e9ec2dd18dfdc9427b19900b37dfe6f40b", size = 844442 },
+    { url = "https://files.pythonhosted.org/packages/e5/44/810cb113096a1dacbe82789fbfab2823f79d19b7f1271acecb7009ba9b88/regex-2026.4.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:eb59c65069498dbae3c0ef07bbe224e1eaa079825a437fb47a479f0af11f774f", size = 789162 },
+    { url = "https://files.pythonhosted.org/packages/20/96/9647dd7f2ecf6d9ce1fb04dfdb66910d094e10d8fe53e9c15096d8aa0bd2/regex-2026.4.4-cp311-cp311-win32.whl", hash = "sha256:2a5d273181b560ef8397c8825f2b9d57013de744da9e8257b8467e5da8599351", size = 266227 },
+    { url = "https://files.pythonhosted.org/packages/33/80/74e13262460530c3097ff343a17de9a34d040a5dc4de9cf3a8241faab51c/regex-2026.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:9542ccc1e689e752594309444081582f7be2fdb2df75acafea8a075108566735", size = 278399 },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/39f19f47f19dcefa3403f09d13562ca1c0fd07ab54db2bc03148f3f6b46a/regex-2026.4.4-cp311-cp311-win_arm64.whl", hash = "sha256:b5f9fb784824a042be3455b53d0b112655686fdb7a91f88f095f3fee1e2a2a54", size = 270473 },
+    { url = "https://files.pythonhosted.org/packages/e5/28/b972a4d3df61e1d7bcf1b59fdb3cddef22f88b6be43f161bb41ebc0e4081/regex-2026.4.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c07ab8794fa929e58d97a0e1796b8b76f70943fa39df225ac9964615cf1f9d52", size = 490434 },
+    { url = "https://files.pythonhosted.org/packages/84/20/30041446cf6dc3e0eab344fc62770e84c23b6b68a3b657821f9f80cb69b4/regex-2026.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c785939dc023a1ce4ec09599c032cc9933d258a998d16ca6f2b596c010940eb", size = 292061 },
+    { url = "https://files.pythonhosted.org/packages/62/c8/3baa06d75c98c46d4cc4262b71fd2edb9062b5665e868bca57859dadf93a/regex-2026.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1b1ce5c81c9114f1ce2f9288a51a8fd3aeea33a0cc440c415bf02da323aa0a76", size = 289628 },
+    { url = "https://files.pythonhosted.org/packages/31/87/3accf55634caad8c0acab23f5135ef7d4a21c39f28c55c816ae012931408/regex-2026.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:760ef21c17d8e6a4fe8cf406a97cf2806a4df93416ccc82fc98d25b1c20425be", size = 796651 },
+    { url = "https://files.pythonhosted.org/packages/f6/0c/aaa2c83f34efedbf06f61cb1942c25f6cf1ee3b200f832c4d05f28306c2e/regex-2026.4.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7088fcdcb604a4417c208e2169715800d28838fefd7455fbe40416231d1d47c1", size = 865916 },
+    { url = "https://files.pythonhosted.org/packages/d9/f6/8c6924c865124643e8f37823eca845dc27ac509b2ee58123685e71cd0279/regex-2026.4.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:07edca1ba687998968f7db5bc355288d0c6505caa7374f013d27356d93976d13", size = 912287 },
+    { url = "https://files.pythonhosted.org/packages/11/0e/a9f6f81013e0deaf559b25711623864970fe6a098314e374ccb1540a4152/regex-2026.4.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:993f657a7c1c6ec51b5e0ba97c9817d06b84ea5fa8d82e43b9405de0defdc2b9", size = 801126 },
+    { url = "https://files.pythonhosted.org/packages/71/61/3a0cc8af2dc0c8deb48e644dd2521f173f7e6513c6e195aad9aa8dd77ac5/regex-2026.4.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2b69102a743e7569ebee67e634a69c4cb7e59d6fa2e1aa7d3bdbf3f61435f62d", size = 776788 },
+    { url = "https://files.pythonhosted.org/packages/64/0b/8bb9cbf21ef7dee58e49b0fdb066a7aded146c823202e16494a36777594f/regex-2026.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6dac006c8b6dda72d86ea3d1333d45147de79a3a3f26f10c1cf9287ca4ca0ac3", size = 785184 },
+    { url = "https://files.pythonhosted.org/packages/99/c2/d3e80e8137b25ee06c92627de4e4d98b94830e02b3e6f81f3d2e3f504cf5/regex-2026.4.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:50a766ee2010d504554bfb5f578ed2e066898aa26411d57e6296230627cdefa0", size = 859913 },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/9d5d876157d969c804622456ef250017ac7a8f83e0e14f903b9e6df5ce95/regex-2026.4.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9e2f5217648f68e3028c823df58663587c1507a5ba8419f4fdfc8a461be76043", size = 765732 },
+    { url = "https://files.pythonhosted.org/packages/82/80/b568935b4421388561c8ed42aff77247285d3ae3bb2a6ca22af63bae805e/regex-2026.4.4-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:39d8de85a08e32632974151ba59c6e9140646dcc36c80423962b1c5c0a92e244", size = 852152 },
+    { url = "https://files.pythonhosted.org/packages/39/29/f0f81217e21cd998245da047405366385d5c6072048038a3d33b37a79dc0/regex-2026.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:55d9304e0e7178dfb1e106c33edf834097ddf4a890e2f676f6c5118f84390f73", size = 789076 },
+    { url = "https://files.pythonhosted.org/packages/49/1d/1d957a61976ab9d4e767dd4f9d04b66cc0c41c5e36cf40e2d43688b5ae6f/regex-2026.4.4-cp312-cp312-win32.whl", hash = "sha256:04bb679bc0bde8a7bfb71e991493d47314e7b98380b083df2447cda4b6edb60f", size = 266700 },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/bf575d396aeb58ea13b06ef2adf624f65b70fafef6950a80fc3da9cae3bc/regex-2026.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:db0ac18435a40a2543dbb3d21e161a6c78e33e8159bd2e009343d224bb03bb1b", size = 277768 },
+    { url = "https://files.pythonhosted.org/packages/c9/27/049df16ec6a6828ccd72add3c7f54b4df029669bea8e9817df6fff58be90/regex-2026.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:4ce255cc05c1947a12989c6db801c96461947adb7a59990f1360b5983fab4983", size = 270568 },
+]
+
+[[package]]
+name = "requests"
+version = "2.28.1"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+wheels = [
+    { url = "https://download.pytorch.org/whl/requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349" },
+]
+
+[[package]]
+name = "rfc3986"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/30/5b1b6c28c105629cc12b33bdcbb0b11b5bb1880c6cfbd955f9e792921aa8/rfc3986-1.5.0.tar.gz", hash = "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835", size = 49378 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/e5/63ca2c4edf4e00657584608bee1001302bbf8c5f569340b78304f2f446cb/rfc3986-1.5.0-py2.py3-none-any.whl", hash = "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97", size = 31976 },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/0c/0c411a0ec64ccb6d104dcabe0e713e05e153a9a2c3c2bd2b32ce412166fe/rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288", size = 370490 },
+    { url = "https://files.pythonhosted.org/packages/19/6a/4ba3d0fb7297ebae71171822554abe48d7cab29c28b8f9f2c04b79988c05/rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00", size = 359751 },
+    { url = "https://files.pythonhosted.org/packages/cd/7c/e4933565ef7f7a0818985d87c15d9d273f1a649afa6a52ea35ad011195ea/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6", size = 389696 },
+    { url = "https://files.pythonhosted.org/packages/5e/01/6271a2511ad0815f00f7ed4390cf2567bec1d4b1da39e2c27a41e6e3b4de/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7", size = 403136 },
+    { url = "https://files.pythonhosted.org/packages/55/64/c857eb7cd7541e9b4eee9d49c196e833128a55b89a9850a9c9ac33ccf897/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324", size = 524699 },
+    { url = "https://files.pythonhosted.org/packages/9c/ed/94816543404078af9ab26159c44f9e98e20fe47e2126d5d32c9d9948d10a/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df", size = 412022 },
+    { url = "https://files.pythonhosted.org/packages/61/b5/707f6cf0066a6412aacc11d17920ea2e19e5b2f04081c64526eb35b5c6e7/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3", size = 390522 },
+    { url = "https://files.pythonhosted.org/packages/13/4e/57a85fda37a229ff4226f8cbcf09f2a455d1ed20e802ce5b2b4a7f5ed053/rpds_py-0.30.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221", size = 404579 },
+    { url = "https://files.pythonhosted.org/packages/f9/da/c9339293513ec680a721e0e16bf2bac3db6e5d7e922488de471308349bba/rpds_py-0.30.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7", size = 421305 },
+    { url = "https://files.pythonhosted.org/packages/f9/be/522cb84751114f4ad9d822ff5a1aa3c98006341895d5f084779b99596e5c/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff", size = 572503 },
+    { url = "https://files.pythonhosted.org/packages/a2/9b/de879f7e7ceddc973ea6e4629e9b380213a6938a249e94b0cdbcc325bb66/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7", size = 598322 },
+    { url = "https://files.pythonhosted.org/packages/48/ac/f01fc22efec3f37d8a914fc1b2fb9bcafd56a299edbe96406f3053edea5a/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139", size = 560792 },
+    { url = "https://files.pythonhosted.org/packages/e2/da/4e2b19d0f131f35b6146425f846563d0ce036763e38913d917187307a671/rpds_py-0.30.0-cp310-cp310-win32.whl", hash = "sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464", size = 221901 },
+    { url = "https://files.pythonhosted.org/packages/96/cb/156d7a5cf4f78a7cc571465d8aec7a3c447c94f6749c5123f08438bcf7bc/rpds_py-0.30.0-cp310-cp310-win_amd64.whl", hash = "sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169", size = 235823 },
+    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157 },
+    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676 },
+    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938 },
+    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", size = 402932 },
+    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", size = 525830 },
+    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", size = 412033 },
+    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", size = 390828 },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", size = 404683 },
+    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", size = 421583 },
+    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", size = 572496 },
+    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", size = 598669 },
+    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", size = 561011 },
+    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", size = 221406 },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", size = 236024 },
+    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", size = 229069 },
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086 },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053 },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763 },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951 },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622 },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492 },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080 },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680 },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589 },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289 },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737 },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120 },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782 },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463 },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868 },
+    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", size = 372292 },
+    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", size = 362128 },
+    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", size = 391542 },
+    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", size = 404004 },
+    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", size = 527063 },
+    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", size = 413099 },
+    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", size = 392177 },
+    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", size = 406015 },
+    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", size = 423736 },
+    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981 },
+    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782 },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191 },
+]
+
+[[package]]
+name = "safetensors"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/9c/6e74567782559a63bd040a236edca26fd71bc7ba88de2ef35d75df3bca5e/safetensors-0.7.0.tar.gz", hash = "sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0", size = 200878 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/47/aef6c06649039accf914afef490268e1067ed82be62bcfa5b7e886ad15e8/safetensors-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c82f4d474cf725255d9e6acf17252991c3c8aac038d6ef363a4bf8be2f6db517", size = 467781 },
+    { url = "https://files.pythonhosted.org/packages/e8/00/374c0c068e30cd31f1e1b46b4b5738168ec79e7689ca82ee93ddfea05109/safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57", size = 447058 },
+    { url = "https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07d91d0c92a31200f25351f4acb2bc6aff7f48094e13ebb1d0fb995b54b6542", size = 491748 },
+    { url = "https://files.pythonhosted.org/packages/ae/33/1debbbb70e4791dde185edb9413d1fe01619255abb64b300157d7f15dddd/safetensors-0.7.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8469155f4cb518bafb4acf4865e8bb9d6804110d2d9bdcaa78564b9fd841e104", size = 503881 },
+    { url = "https://files.pythonhosted.org/packages/8e/1c/40c2ca924d60792c3be509833df711b553c60effbd91da6f5284a83f7122/safetensors-0.7.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54bef08bf00a2bff599982f6b08e8770e09cc012d7bba00783fc7ea38f1fb37d", size = 623463 },
+    { url = "https://files.pythonhosted.org/packages/9b/3a/13784a9364bd43b0d61eef4bea2845039bc2030458b16594a1bd787ae26e/safetensors-0.7.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:42cb091236206bb2016d245c377ed383aa7f78691748f3bb6ee1bfa51ae2ce6a", size = 532855 },
+    { url = "https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac7252938f0696ddea46f5e855dd3138444e82236e3be475f54929f0c510d48", size = 507152 },
+    { url = "https://files.pythonhosted.org/packages/3c/a8/4b45e4e059270d17af60359713ffd83f97900d45a6afa73aaa0d737d48b6/safetensors-0.7.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1d060c70284127fa805085d8f10fbd0962792aed71879d00864acda69dbab981", size = 541856 },
+    { url = "https://files.pythonhosted.org/packages/06/87/d26d8407c44175d8ae164a95b5a62707fcc445f3c0c56108e37d98070a3d/safetensors-0.7.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cdab83a366799fa730f90a4ebb563e494f28e9e92c4819e556152ad55e43591b", size = 674060 },
+    { url = "https://files.pythonhosted.org/packages/11/f5/57644a2ff08dc6325816ba7217e5095f17269dada2554b658442c66aed51/safetensors-0.7.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:672132907fcad9f2aedcb705b2d7b3b93354a2aec1b2f706c4db852abe338f85", size = 771715 },
+    { url = "https://files.pythonhosted.org/packages/86/31/17883e13a814bd278ae6e266b13282a01049b0c81341da7fd0e3e71a80a3/safetensors-0.7.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:5d72abdb8a4d56d4020713724ba81dac065fedb7f3667151c4a637f1d3fb26c0", size = 714377 },
+    { url = "https://files.pythonhosted.org/packages/4a/d8/0c8a7dc9b41dcac53c4cbf9df2b9c83e0e0097203de8b37a712b345c0be5/safetensors-0.7.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0f6d66c1c538d5a94a73aa9ddca8ccc4227e6c9ff555322ea40bdd142391dd4", size = 677368 },
+    { url = "https://files.pythonhosted.org/packages/05/e5/cb4b713c8a93469e3c5be7c3f8d77d307e65fe89673e731f5c2bfd0a9237/safetensors-0.7.0-cp38-abi3-win32.whl", hash = "sha256:c74af94bf3ac15ac4d0f2a7c7b4663a15f8c2ab15ed0fc7531ca61d0835eccba", size = 326423 },
+    { url = "https://files.pythonhosted.org/packages/5d/e6/ec8471c8072382cb91233ba7267fd931219753bb43814cbc71757bfd4dab/safetensors-0.7.0-cp38-abi3-win_amd64.whl", hash = "sha256:d1239932053f56f3456f32eb9625590cc7582e905021f94636202a864d470755", size = 341380 },
+    { url = "https://files.pythonhosted.org/packages/a7/6a/4d08d89a6fcbe905c5ae68b8b34f0791850882fc19782d0d02c65abbdf3b/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4729811a6640d019a4b7ba8638ee2fd21fa5ca8c7e7bdf0fed62068fcaac737", size = 492430 },
+    { url = "https://files.pythonhosted.org/packages/dd/29/59ed8152b30f72c42d00d241e58eaca558ae9dbfa5695206e2e0f54c7063/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12f49080303fa6bb424b362149a12949dfbbf1e06811a88f2307276b0c131afd", size = 503977 },
+    { url = "https://files.pythonhosted.org/packages/d3/0b/4811bfec67fa260e791369b16dab105e4bae82686120554cc484064e22b4/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0071bffba4150c2f46cae1432d31995d77acfd9f8db598b5d1a2ce67e8440ad2", size = 623890 },
+    { url = "https://files.pythonhosted.org/packages/58/5b/632a58724221ef03d78ab65062e82a1010e1bef8e8e0b9d7c6d7b8044841/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:473b32699f4200e69801bf5abf93f1a4ecd432a70984df164fc22ccf39c4a6f3", size = 531885 },
+]
+
+[[package]]
+name = "scipy"
+version = "1.15.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+]
+dependencies = [
+    { name = "numpy", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/2f/4966032c5f8cc7e6a60f1b2e0ad686293b9474b65246b0c642e3ef3badd0/scipy-1.15.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:a345928c86d535060c9c2b25e71e87c39ab2f22fc96e9636bd74d1dbf9de448c", size = 38702770 },
+    { url = "https://files.pythonhosted.org/packages/a0/6e/0c3bf90fae0e910c274db43304ebe25a6b391327f3f10b5dcc638c090795/scipy-1.15.3-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:ad3432cb0f9ed87477a8d97f03b763fd1d57709f1bbde3c9369b1dff5503b253", size = 30094511 },
+    { url = "https://files.pythonhosted.org/packages/ea/b1/4deb37252311c1acff7f101f6453f0440794f51b6eacb1aad4459a134081/scipy-1.15.3-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:aef683a9ae6eb00728a542b796f52a5477b78252edede72b8327a886ab63293f", size = 22368151 },
+    { url = "https://files.pythonhosted.org/packages/38/7d/f457626e3cd3c29b3a49ca115a304cebb8cc6f31b04678f03b216899d3c6/scipy-1.15.3-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:1c832e1bd78dea67d5c16f786681b28dd695a8cb1fb90af2e27580d3d0967e92", size = 25121732 },
+    { url = "https://files.pythonhosted.org/packages/db/0a/92b1de4a7adc7a15dcf5bddc6e191f6f29ee663b30511ce20467ef9b82e4/scipy-1.15.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:263961f658ce2165bbd7b99fa5135195c3a12d9bef045345016b8b50c315cb82", size = 35547617 },
+    { url = "https://files.pythonhosted.org/packages/8e/6d/41991e503e51fc1134502694c5fa7a1671501a17ffa12716a4a9151af3df/scipy-1.15.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e2abc762b0811e09a0d3258abee2d98e0c703eee49464ce0069590846f31d40", size = 37662964 },
+    { url = "https://files.pythonhosted.org/packages/25/e1/3df8f83cb15f3500478c889be8fb18700813b95e9e087328230b98d547ff/scipy-1.15.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ed7284b21a7a0c8f1b6e5977ac05396c0d008b89e05498c8b7e8f4a1423bba0e", size = 37238749 },
+    { url = "https://files.pythonhosted.org/packages/93/3e/b3257cf446f2a3533ed7809757039016b74cd6f38271de91682aa844cfc5/scipy-1.15.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5380741e53df2c566f4d234b100a484b420af85deb39ea35a1cc1be84ff53a5c", size = 40022383 },
+    { url = "https://files.pythonhosted.org/packages/d1/84/55bc4881973d3f79b479a5a2e2df61c8c9a04fcb986a213ac9c02cfb659b/scipy-1.15.3-cp310-cp310-win_amd64.whl", hash = "sha256:9d61e97b186a57350f6d6fd72640f9e99d5a4a2b8fbf4b9ee9a841eab327dc13", size = 41259201 },
+    { url = "https://files.pythonhosted.org/packages/96/ab/5cc9f80f28f6a7dff646c5756e559823614a42b1939d86dd0ed550470210/scipy-1.15.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:993439ce220d25e3696d1b23b233dd010169b62f6456488567e830654ee37a6b", size = 38714255 },
+    { url = "https://files.pythonhosted.org/packages/4a/4a/66ba30abe5ad1a3ad15bfb0b59d22174012e8056ff448cb1644deccbfed2/scipy-1.15.3-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:34716e281f181a02341ddeaad584205bd2fd3c242063bd3423d61ac259ca7eba", size = 30111035 },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/a7e5b95afd80d24313307f03624acc65801846fa75599034f8ceb9e2cbf6/scipy-1.15.3-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3b0334816afb8b91dab859281b1b9786934392aa3d527cd847e41bb6f45bee65", size = 22384499 },
+    { url = "https://files.pythonhosted.org/packages/17/99/f3aaddccf3588bb4aea70ba35328c204cadd89517a1612ecfda5b2dd9d7a/scipy-1.15.3-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:6db907c7368e3092e24919b5e31c76998b0ce1684d51a90943cb0ed1b4ffd6c1", size = 25152602 },
+    { url = "https://files.pythonhosted.org/packages/56/c5/1032cdb565f146109212153339f9cb8b993701e9fe56b1c97699eee12586/scipy-1.15.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:721d6b4ef5dc82ca8968c25b111e307083d7ca9091bc38163fb89243e85e3889", size = 35503415 },
+    { url = "https://files.pythonhosted.org/packages/bd/37/89f19c8c05505d0601ed5650156e50eb881ae3918786c8fd7262b4ee66d3/scipy-1.15.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39cb9c62e471b1bb3750066ecc3a3f3052b37751c7c3dfd0fd7e48900ed52982", size = 37652622 },
+    { url = "https://files.pythonhosted.org/packages/7e/31/be59513aa9695519b18e1851bb9e487de66f2d31f835201f1b42f5d4d475/scipy-1.15.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:795c46999bae845966368a3c013e0e00947932d68e235702b5c3f6ea799aa8c9", size = 37244796 },
+    { url = "https://files.pythonhosted.org/packages/10/c0/4f5f3eeccc235632aab79b27a74a9130c6c35df358129f7ac8b29f562ac7/scipy-1.15.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:18aaacb735ab38b38db42cb01f6b92a2d0d4b6aabefeb07f02849e47f8fb3594", size = 40047684 },
+    { url = "https://files.pythonhosted.org/packages/ab/a7/0ddaf514ce8a8714f6ed243a2b391b41dbb65251affe21ee3077ec45ea9a/scipy-1.15.3-cp311-cp311-win_amd64.whl", hash = "sha256:ae48a786a28412d744c62fd7816a4118ef97e5be0bee968ce8f0a2fba7acf3bb", size = 41246504 },
+    { url = "https://files.pythonhosted.org/packages/37/4b/683aa044c4162e10ed7a7ea30527f2cbd92e6999c10a8ed8edb253836e9c/scipy-1.15.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6ac6310fdbfb7aa6612408bd2f07295bcbd3fda00d2d702178434751fe48e019", size = 38766735 },
+    { url = "https://files.pythonhosted.org/packages/7b/7e/f30be3d03de07f25dc0ec926d1681fed5c732d759ac8f51079708c79e680/scipy-1.15.3-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:185cd3d6d05ca4b44a8f1595af87f9c372bb6acf9c808e99aa3e9aa03bd98cf6", size = 30173284 },
+    { url = "https://files.pythonhosted.org/packages/07/9c/0ddb0d0abdabe0d181c1793db51f02cd59e4901da6f9f7848e1f96759f0d/scipy-1.15.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:05dc6abcd105e1a29f95eada46d4a3f251743cfd7d3ae8ddb4088047f24ea477", size = 22446958 },
+    { url = "https://files.pythonhosted.org/packages/af/43/0bce905a965f36c58ff80d8bea33f1f9351b05fad4beaad4eae34699b7a1/scipy-1.15.3-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:06efcba926324df1696931a57a176c80848ccd67ce6ad020c810736bfd58eb1c", size = 25242454 },
+    { url = "https://files.pythonhosted.org/packages/56/30/a6f08f84ee5b7b28b4c597aca4cbe545535c39fe911845a96414700b64ba/scipy-1.15.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c05045d8b9bfd807ee1b9f38761993297b10b245f012b11b13b91ba8945f7e45", size = 35210199 },
+    { url = "https://files.pythonhosted.org/packages/0b/1f/03f52c282437a168ee2c7c14a1a0d0781a9a4a8962d84ac05c06b4c5b555/scipy-1.15.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:271e3713e645149ea5ea3e97b57fdab61ce61333f97cfae392c28ba786f9bb49", size = 37309455 },
+    { url = "https://files.pythonhosted.org/packages/89/b1/fbb53137f42c4bf630b1ffdfc2151a62d1d1b903b249f030d2b1c0280af8/scipy-1.15.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6cfd56fc1a8e53f6e89ba3a7a7251f7396412d655bca2aa5611c8ec9a6784a1e", size = 36885140 },
+    { url = "https://files.pythonhosted.org/packages/2e/2e/025e39e339f5090df1ff266d021892694dbb7e63568edcfe43f892fa381d/scipy-1.15.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0ff17c0bb1cb32952c09217d8d1eed9b53d1463e5f1dd6052c7857f83127d539", size = 39710549 },
+    { url = "https://files.pythonhosted.org/packages/e6/eb/3bf6ea8ab7f1503dca3a10df2e4b9c3f6b3316df07f6c0ded94b281c7101/scipy-1.15.3-cp312-cp312-win_amd64.whl", hash = "sha256:52092bc0472cfd17df49ff17e70624345efece4e1a12b23783a1ac59a1b728ed", size = 40966184 },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11' and sys_platform != 'darwin'",
+    "python_full_version >= '3.11' and sys_platform == 'darwin'",
+]
+dependencies = [
+    { name = "numpy", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/75/b4ce781849931fef6fd529afa6b63711d5a733065722d0c3e2724af9e40a/scipy-1.17.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:1f95b894f13729334fb990162e911c9e5dc1ab390c58aa6cbecb389c5b5e28ec", size = 31613675 },
+    { url = "https://files.pythonhosted.org/packages/f7/58/bccc2861b305abdd1b8663d6130c0b3d7cc22e8d86663edbc8401bfd40d4/scipy-1.17.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:e18f12c6b0bc5a592ed23d3f7b891f68fd7f8241d69b7883769eb5d5dfb52696", size = 28162057 },
+    { url = "https://files.pythonhosted.org/packages/6d/ee/18146b7757ed4976276b9c9819108adbc73c5aad636e5353e20746b73069/scipy-1.17.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:a3472cfbca0a54177d0faa68f697d8ba4c80bbdc19908c3465556d9f7efce9ee", size = 20334032 },
+    { url = "https://files.pythonhosted.org/packages/ec/e6/cef1cf3557f0c54954198554a10016b6a03b2ec9e22a4e1df734936bd99c/scipy-1.17.1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:766e0dc5a616d026a3a1cffa379af959671729083882f50307e18175797b3dfd", size = 22709533 },
+    { url = "https://files.pythonhosted.org/packages/4d/60/8804678875fc59362b0fb759ab3ecce1f09c10a735680318ac30da8cd76b/scipy-1.17.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:744b2bf3640d907b79f3fd7874efe432d1cf171ee721243e350f55234b4cec4c", size = 33062057 },
+    { url = "https://files.pythonhosted.org/packages/09/7d/af933f0f6e0767995b4e2d705a0665e454d1c19402aa7e895de3951ebb04/scipy-1.17.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43af8d1f3bea642559019edfe64e9b11192a8978efbd1539d7bc2aaa23d92de4", size = 35349300 },
+    { url = "https://files.pythonhosted.org/packages/b4/3d/7ccbbdcbb54c8fdc20d3b6930137c782a163fa626f0aef920349873421ba/scipy-1.17.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd96a1898c0a47be4520327e01f874acfd61fb48a9420f8aa9f6483412ffa444", size = 35127333 },
+    { url = "https://files.pythonhosted.org/packages/e8/19/f926cb11c42b15ba08e3a71e376d816ac08614f769b4f47e06c3580c836a/scipy-1.17.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4eb6c25dd62ee8d5edf68a8e1c171dd71c292fdae95d8aeb3dd7d7de4c364082", size = 37741314 },
+    { url = "https://files.pythonhosted.org/packages/95/da/0d1df507cf574b3f224ccc3d45244c9a1d732c81dcb26b1e8a766ae271a8/scipy-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:d30e57c72013c2a4fe441c2fcb8e77b14e152ad48b5464858e07e2ad9fbfceff", size = 36607512 },
+    { url = "https://files.pythonhosted.org/packages/68/7f/bdd79ceaad24b671543ffe0ef61ed8e659440eb683b66f033454dcee90eb/scipy-1.17.1-cp311-cp311-win_arm64.whl", hash = "sha256:9ecb4efb1cd6e8c4afea0daa91a87fbddbce1b99d2895d151596716c0b2e859d", size = 24599248 },
+    { url = "https://files.pythonhosted.org/packages/35/48/b992b488d6f299dbe3f11a20b24d3dda3d46f1a635ede1c46b5b17a7b163/scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8", size = 31610954 },
+    { url = "https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76", size = 28172662 },
+    { url = "https://files.pythonhosted.org/packages/cf/a9/599c28631bad314d219cf9ffd40e985b24d603fc8a2f4ccc5ae8419a535b/scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086", size = 20344366 },
+    { url = "https://files.pythonhosted.org/packages/35/f5/906eda513271c8deb5af284e5ef0206d17a96239af79f9fa0aebfe0e36b4/scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b", size = 22704017 },
+    { url = "https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21", size = 32927842 },
+    { url = "https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458", size = 35235890 },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/9d7f4c88bea6e0d5a4f1bc0506a53a00e9fcb198de372bfe4d3652cef482/scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb", size = 35003557 },
+    { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856 },
+    { url = "https://files.pythonhosted.org/packages/a2/84/dc08d77fbf3d87d3ee27f6a0c6dcce1de5829a64f2eae85a0ecc1f0daa73/scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87", size = 36549682 },
+    { url = "https://files.pythonhosted.org/packages/bc/98/fe9ae9ffb3b54b62559f52dedaebe204b408db8109a8c66fdd04869e6424/scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3", size = 24547340 },
+]
+
+[[package]]
+name = "segments"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "csvw" },
+    { name = "regex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/57/85cac3a8e32370e88fa5fa92812edb6025db7fcbed51452bd56ee1524957/segments-2.4.0.tar.gz", hash = "sha256:bba71f5520ddd54c8aa2f4d765a60618c6862162d6e7356a4a097f2223166f5b", size = 18662 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/60/eef9acce946177f92c9aabf432224d87ab908bafafac516a36ab924199f3/segments-2.4.0-py2.py3-none-any.whl", hash = "sha256:4021dc67f201cc03c864c74c618bdb163b1af629da3040babbaa37d8813f3db0", size = 16321 },
+]
+
+[[package]]
+name = "setuptools"
+version = "70.2.0"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+wheels = [
+    { url = "https://download.pytorch.org/whl/setuptools-70.2.0-py3-none-any.whl", hash = "sha256:b8b8060bb426838fbe942479c90296ce976249451118ef566a5a0b7d8b78fb05" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
+]
+
+[[package]]
+name = "soundfile"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/41/9b873a8c055582859b239be17902a85339bec6a30ad162f98c9b0288a2cc/soundfile-0.13.1.tar.gz", hash = "sha256:b2c68dab1e30297317080a5b43df57e302584c49e2942defdde0acccc53f0e5b", size = 46156 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/28/e2a36573ccbcf3d57c00626a21fe51989380636e821b341d36ccca0c1c3a/soundfile-0.13.1-py2.py3-none-any.whl", hash = "sha256:a23c717560da2cf4c7b5ae1142514e0fd82d6bbd9dfc93a50423447142f2c445", size = 25751 },
+    { url = "https://files.pythonhosted.org/packages/ea/ab/73e97a5b3cc46bba7ff8650a1504348fa1863a6f9d57d7001c6b67c5f20e/soundfile-0.13.1-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:82dc664d19831933fe59adad199bf3945ad06d84bc111a5b4c0d3089a5b9ec33", size = 1142250 },
+    { url = "https://files.pythonhosted.org/packages/a0/e5/58fd1a8d7b26fc113af244f966ee3aecf03cb9293cb935daaddc1e455e18/soundfile-0.13.1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:743f12c12c4054921e15736c6be09ac26b3b3d603aef6fd69f9dde68748f2593", size = 1101406 },
+    { url = "https://files.pythonhosted.org/packages/58/ae/c0e4a53d77cf6e9a04179535766b3321b0b9ced5f70522e4caf9329f0046/soundfile-0.13.1-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:9c9e855f5a4d06ce4213f31918653ab7de0c5a8d8107cd2427e44b42df547deb", size = 1235729 },
+    { url = "https://files.pythonhosted.org/packages/57/5e/70bdd9579b35003a489fc850b5047beeda26328053ebadc1fb60f320f7db/soundfile-0.13.1-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:03267c4e493315294834a0870f31dbb3b28a95561b80b134f0bd3cf2d5f0e618", size = 1313646 },
+    { url = "https://files.pythonhosted.org/packages/fe/df/8c11dc4dfceda14e3003bb81a0d0edcaaf0796dd7b4f826ea3e532146bba/soundfile-0.13.1-py2.py3-none-win32.whl", hash = "sha256:c734564fab7c5ddf8e9be5bf70bab68042cd17e9c214c06e365e20d64f9a69d5", size = 899881 },
+    { url = "https://files.pythonhosted.org/packages/14/e9/6b761de83277f2f02ded7e7ea6f07828ec78e4b229b80e4ca55dd205b9dc/soundfile-0.13.1-py2.py3-none-win_amd64.whl", hash = "sha256:1e70a05a0626524a69e9f0f4dd2ec174b4e9567f4d8b6c11d38b5c289be36ee9", size = 1019162 },
+]
+
+[[package]]
+name = "styletts2-coreml"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "coremltools" },
+    { name = "einops" },
+    { name = "einops-exts" },
+    { name = "huggingface-hub" },
+    { name = "munch" },
+    { name = "numpy" },
+    { name = "phonemizer" },
+    { name = "pyyaml" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "soundfile" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "torchaudio", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torchaudio", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "transformers" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "coremltools", specifier = ">=8.0,<9.0" },
+    { name = "einops", specifier = ">=0.7" },
+    { name = "einops-exts", specifier = ">=0.0.4" },
+    { name = "huggingface-hub", specifier = ">=0.10" },
+    { name = "munch", specifier = ">=4.0" },
+    { name = "numpy", specifier = ">=1.24,<2.0" },
+    { name = "phonemizer", specifier = ">=3.2.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "scipy", specifier = ">=1.5.0" },
+    { name = "soundfile", specifier = ">=0.12.0" },
+    { name = "torch", specifier = ">=2.5.0", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "torchaudio", specifier = ">=2.5.0" },
+    { name = "transformers", specifier = ">=4.40,<5.0" },
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5" },
+]
+
+[[package]]
+name = "termcolor"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734 },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275 },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472 },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736 },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835 },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673 },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818 },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195 },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982 },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245 },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069 },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263 },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429 },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363 },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786 },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133 },
+    { url = "https://files.pythonhosted.org/packages/84/04/655b79dbcc9b3ac5f1479f18e931a344af67e5b7d3b251d2dcdcd7558592/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:753d47ebd4542742ef9261d9da92cd545b2cacbb48349a1225466745bb866ec4", size = 3282301 },
+    { url = "https://files.pythonhosted.org/packages/46/cd/e4851401f3d8f6f45d8480262ab6a5c8cb9c4302a790a35aa14eeed6d2fd/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e10bf9113d209be7cd046d40fbabbaf3278ff6d18eb4da4c500443185dc1896c", size = 3161308 },
+    { url = "https://files.pythonhosted.org/packages/6f/6e/55553992a89982cd12d4a66dddb5e02126c58677ea3931efcbe601d419db/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:64d94e84f6660764e64e7e0b22baa72f6cd942279fdbb21d46abd70d179f0195", size = 3718964 },
+    { url = "https://files.pythonhosted.org/packages/59/8c/b1c87148aa15e099243ec9f0cf9d0e970cc2234c3257d558c25a2c5304e6/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f01a9c019878532f98927d2bacb79bbb404b43d3437455522a00a30718cdedb5", size = 3373542 },
+]
+
+[[package]]
+name = "torch"
+version = "2.11.0"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+]
+dependencies = [
+    { name = "filelock", marker = "sys_platform == 'darwin'" },
+    { name = "fsspec", marker = "sys_platform == 'darwin'" },
+    { name = "jinja2", marker = "sys_platform == 'darwin'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11' and sys_platform == 'darwin'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.11' and sys_platform == 'darwin'" },
+    { name = "setuptools", marker = "sys_platform == 'darwin'" },
+    { name = "sympy", marker = "sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:91209c7d8a2460b76e8ff5b28b7623da4ab1d27474b79e1de83e954871985afe" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d75eadcd97fe0dc7cd0eedc4d72152484c19cb2cfe46ce55766c8e129116425f" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:43b35116802c85fb88d99f4a396b8bd4472bfca1dd82e69499e5a4f9b8b4e252" },
+]
+
+[[package]]
+name = "torch"
+version = "2.11.0+cpu"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+]
+dependencies = [
+    { name = "filelock", marker = "sys_platform != 'darwin'" },
+    { name = "fsspec", marker = "sys_platform != 'darwin'" },
+    { name = "jinja2", marker = "sys_platform != 'darwin'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11' and sys_platform != 'darwin'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.11' and sys_platform != 'darwin'" },
+    { name = "setuptools", marker = "sys_platform != 'darwin'" },
+    { name = "sympy", marker = "sys_platform != 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp310-cp310-linux_s390x.whl", hash = "sha256:3d8a7789e61dbf11f8922672c43354614b9b0debd40899c0a94f1ad9e0bd6bd9" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:c7dbae3a5cd0a4a3eab760742b9be3bd79282259488cf83176197cef31ce1610" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:f378df648bf7fb94bbc820dfec37d3d346bd1703c692a2215edebf6edcef8b75" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp310-cp310-win_amd64.whl", hash = "sha256:fe708aa0c1df5cce9962df806065534ae9af5eb29ee6145a705176266427c931" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:5214b203ee187f8746c66f1378b72611b7c1e15c5cb325037541899e705ea24e" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:46fbb0aa257bb781efbfad648f5b045c0e232573b661f1461593db61342e9096" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:8a56a8c95531ef0e454510ba8bbd9d11dc7a9000337265210b10f6bfeacdd485" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:51a221769d4a316f4b47a786c12e67c3f4807db8ed13c7b8817ebe73786acbbc" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:2db3ae5404e32cb42b5fcbd94f13607761eaec0cf1687fde95095289d1e26cfb" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:70ecb2659af6373b7c5336e692e665605b0201ea21ff51aaea47e1d75ea6b5aa" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:f82e2ae20c1545bb03997d1cc3143d94e14b800038669ee1aca45808a9acc338" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:1abeaa46fa7532ed35ed79146f4de5d7a9d4b30462c98052ea4ddfe781ea3eca" },
+]
+
+[[package]]
+name = "torchaudio"
+version = "2.11.0"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6ebb59c694909eccb5d61b7cc199d297692012c43286e36d92983aa7bad7586d" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:492dd64645e9d0bb843e94f1d9a4d1e31426262ffc594fafecc1697df9df5eb9" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a1cf1acc883bee9cb906a933572fed6a8a933f86ef34e9ea7d803f72317e8c1b" },
+]
+
+[[package]]
+name = "torchaudio"
+version = "2.11.0+cpu"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.11.0%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:42ce393036ca6ac507226a7a6cf83be29c8c0a51c3fb775498f8b1563f476387" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.11.0%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:64c0a3591a5d343640ca5fc5ccdac3ef9d8bcb5928e24c97acfb9f84cb8487a9" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.11.0%2Bcpu-cp310-cp310-win_amd64.whl", hash = "sha256:fae220128cbfe060c663fbb2a1967b88c605f9eb49b535903cca694011662534" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.11.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:7a5ecdd20fb26d8eb1d62135ddc6db0f806b17667c10e82df913fd509d1f5cfe" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.11.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:2ddcb49458aa9783121222c535c0eb9cd54445ec44bb8dd22c9e52cdb730dbc2" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.11.0%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:abbff04127caf6e16e3a7c3e1ca2739b68899e14926d7cbec4bd8b40f72375d5" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.11.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b9dd2c6ac144001dc6dac38b564c1de73ac26ef0c195d5037c4a94990b0e2b5a" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.11.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:2354248848d06a9ae1e7a12165f800f0dda7df60ecac9fca892322b722b922c0" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.11.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:95d517bd1a0a28dacd1c37550ced95cab64f3a7a4ef9b8219b41049388a71163" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.66.5"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+wheels = [
+    { url = "https://download.pytorch.org/whl/tqdm-4.66.5-py3-none-any.whl", hash = "sha256:90279a3770753eafc9194a0364852159802111925aa30eb3f9d85b0e805ac7cd" },
+]
+
+[[package]]
+name = "transformers"
+version = "4.57.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "requests" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/35/67252acc1b929dc88b6602e8c4a982e64f31e733b804c14bc24b47da35e6/transformers-4.57.6.tar.gz", hash = "sha256:55e44126ece9dc0a291521b7e5492b572e6ef2766338a610b9ab5afbb70689d3", size = 10134912 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl", hash = "sha256:4c9e9de11333ddfe5114bc872c9f370509198acf0b87a832a0ab9458e2bd0550", size = 11993498 },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+wheels = [
+    { url = "https://download.pytorch.org/whl/typing_extensions-4.15.0-py3-none-any.whl" },
+]
+
+[[package]]
+name = "uritemplate"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488 },
+]
+
+[[package]]
+name = "urllib3"
+version = "1.26.13"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+wheels = [
+    { url = "https://download.pytorch.org/whl/urllib3-1.26.13-py2.py3-none-any.whl", hash = "sha256:47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc" },
+]


### PR DESCRIPTION
## Summary

Port [yl4579/StyleTTS2](https://github.com/yl4579/StyleTTS2) (LibriTTS multi-speaker checkpoint) to CoreML for on-device inference on Apple Silicon. Four-stage pipeline with mixed precision and per-stage compute-unit placement.

## Headline numbers

- **RTFx:** 4.32× warm (M-series Mac, 5-step ADPM2 sampler)
- **On-disk size:** ~1.4 GB (decoder is fp32; fp16 produces robotic audio — see `coreml/PHASE6_FP16_DECODER.md`)
- **Log-mel cosine vs PyTorch fp32:** 0.9687
- **Voice-clone fidelity:** at the model's architectural ceiling — see TRIALS.md Phase 5

## Stage layout

| Stage          | Buckets                          | Precision       | Compute unit |
|----------------|----------------------------------|-----------------|--------------|
| text_predictor | 5 token (32, 64, 128, 256, 512)  | selective int8  | ANE          |
| diffusion_step | 1 (B=512)                        | fp16            | CPU+GPU      |
| f0n_energy     | dynamic                          | fp16            | ANE          |
| decoder        | 5 mel (256, 512, 1024, 2048, 4096) | **fp32**      | CPU+GPU      |

The ADPM2 sampler loop (5 steps) and the hard-alignment matrix live in Swift; only per-step inference is in CoreML.

## Optimizations applied

1. **Selective int8 PTQ on text_predictor.** `linear_quantize_weights(weight_threshold=200_000)` — same recipe family as `pocket_tts/coreml/PRECISION.md`. 89 MB saved across 5 buckets, log-mel cosine 0.9998 vs fp32.
2. **Diffusion-bucket prune.** Empirically every observed `bert_dur` fits in B=512; the smaller buckets were dead weight (192 MB). Cost ladder is non-linear (B=32 66 ms/step → B=512 152 ms/step) so the worst case adds ~430 ms per utterance to gain 192 MB.
3. **Per-stage compute_units sweep.** ANE for text_predictor + f0n_energy; CPU+GPU for diffusion + decoder (ANE either rejects subgraphs or runs slower for these). Result: RTFx 1.61× → 3.80× → 4.32× warm (final number includes explicit warmup of every package).

## Decoder precision (fp32, not fp16)

Initial export was fp16 (coremltools mlprogram default) and produced audibly robotic synthesis. Root cause: SineGen's harmonic source accumulates phase via `cumsum × 2π × hop=300`, reaching magnitudes ~4000 mid-frame. fp16 precision at that magnitude (~4) is much larger than the per-sample increment (~0.05 rad), scrambling the sin output.

Two viable fp16 stabilizations were investigated and documented (mixed-precision via `op_selector`; v3 phase-mod-2π wrapping — numerically validated, rms 0.0547 matches fp32 0.0551), but both add complexity. We ship fp32 decoders. See `coreml/PHASE6_FP16_DECODER.md`.

## SineGen op-translation fix

Three coremltools translation bugs in `_f02sine` (aten::remainder, two F.interpolate paths) make a vanilla trace produce silent or NaN waveforms. The v2 patch in `_styletts2_lib.install_sinegen_v2_constfold_fix(t_mel)` constant-folds the fracs index and inlines a manual linear lerp; required before tracing each bucket. See `04_export_decoder.py` and `coreml/PHASE6_FP16_DECODER.md`.

## Voice-clone forensics (Phase 5)

User flagged "robotic" audio. Investigation (separate from the SineGen issue):
- GE2E speaker similarity (resemblyzer) noise-floors at ~0.88 on synthetic TTS — useless signal.
- ECAPA-TDNN (`speechbrain/spkrec-ecapa-voxceleb`): cos(OPT, INT8) = 0.9987 → quantization is innocent. cos(INT8, INT8D512) = 0.7881 → bucket prune costs cosine.
- PT vs CoreML head-to-head with real reference: cos(REF, PT) = **0.2933** (PyTorch fp32 itself). cos(REF, CM) = 0.1795. The ECAPA same-speaker threshold is ~0.3.

Conclusion: StyleTTS2's voice-cloning fidelity is bounded by the model architecture, not by CoreML conversion. PyTorch fp32 is at the ceiling.

## Files

- `coreml/PRECISION.md` — mixed-precision recipe + per-stage rationale (decoder fp32 documented)
- `coreml/PHASE6_FP16_DECODER.md` — SineGen op-translation fix + fp16 audio-regression diagnosis
- `coreml/TRIALS.md` — chronological log
- `scripts/01-04_*.py` — per-stage exporters (each with `--trace-only`)
- `scripts/99{,b,c}_*.py` — parity check, baseline e2e, optimized e2e (`99c` now takes `--reference-wav`)
- `scripts/optimize/{quantize_text_predictor_int8,measure_diffusion_buckets}.py`

## Test plan

- [x] Per-stage parity (cosine 0.9999+) via `99_parity_check.py` (raw `s_pred` comparison fixed per Devin)
- [x] E2E log-mel parity vs PyTorch fp32: 0.9687
- [x] ASR round-trip: whisper-small transcribes all 4 variants correctly
- [x] Speaker-ID forensics (ECAPA-TDNN) confirms quantization preserves voice
- [x] Warm RTFx 4.32× measured in `99c_e2e_optimized.py`
- [ ] Swift-side ADPM2 sampler integration (follow-up PR in FluidAudio)

## Devin review (PR #46)

Addressed in 873fbe1:
- 🔴 v1 SineGen shim using broken ops (already removed in b058784 by promoting v2 patch)
- 🔴 Hardcoded user paths in `99c_e2e_optimized.py`, `quantize_text_predictor_int8.py`, `measure_diffusion_buckets.py` — replaced with `Path(__file__).resolve().parent[s][N]`
- 🟡 `99c_e2e_optimized.py` CPU_ONLY → CPU_AND_GPU for diffusion + decoder (matches RTFx claim)
- 🟡 `99c_e2e_optimized.py` argparse with `--reference-wav` (required) and optional `--baseline-wav` (no more crashes on missing /tmp file)
- 🟡 `99_parity_check.py` Stage B compares raw `s_pred` from PT against raw `s_pred` from CoreML (was inadvertently comparing post-blend PT against raw CM)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/mobius/pull/46" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->