### PR TITLE
docs(tts/magpie/coreml): include .mlpackage alongside .mlmodelc in Phase E HF upload list

### DIFF
--- a/models/tts/magpie/coreml/per_module/results/STATUS.md
+++ b/models/tts/magpie/coreml/per_module/results/STATUS.md
@@ -451,9 +451,11 @@ mlmodelc to eliminate per-call dispatch overhead. Update Swift port.
 
 ### Phase E — HuggingFace upload
 Upload both chunked builds to the FluidAudio HF assets repo. User-managed.
+Ship both the source `.mlpackage` (for re-compile / inspection) and the
+compiled `.mlmodelc` (consumed at runtime by `MagpieModelStore`):
 
-- `nanocodec_decoder_v3.mlmodelc` (fp32, default, audibly clean)
-- `nanocodec_decoder_v2.mlmodelc` (fp16, opt-in, fast/ANE, audibly noisy)
+- `nanocodec_decoder_v3.mlpackage` + `nanocodec_decoder_v3.mlmodelc` (fp32, default, audibly clean)
+- `nanocodec_decoder_v2.mlpackage` + `nanocodec_decoder_v2.mlmodelc` (fp16, opt-in, fast/ANE, audibly noisy)
 
 Both share the same I/O contract; the runtime selector lives in
 `MagpieModelStore` (`MagpieNanocodecPrecision`). The legacy


### PR DESCRIPTION
## Summary

- Phase E HF upload list now ships both the source `.mlpackage` (re-compile / inspection) and the compiled `.mlmodelc` (consumed at runtime by `MagpieModelStore`) for both nanocodec v2 (fp16) and v3 (fp32).
- Reflects what was actually uploaded to `FluidInference/magpie-tts-multilingual-357m-coreml`:
  - `nanocodec_decoder_v3.mlpackage` + `.mlmodelc` (fp32, default, audibly clean)
  - `nanocodec_decoder_v2.mlpackage` + `.mlmodelc` (fp16, opt-in, fast/ANE, audibly noisy)
- Legacy v1 (`nanocodec_decoder.mlpackage`) stays in place as fallback.

## Test plan

- [ ] No code changes — STATUS.md only.
- [ ] Verify HF tree on `FluidInference/magpie-tts-multilingual-357m-coreml` matches list.