### PR TITLE
fix(tts/pocket-tts): restore voice cloning against pocket-tts 2.0.0 (#592)

### DIFF
--- a/models/tts/pocket_tts/coreml/convert_models/convert/convert_cond_step.py
+++ b/models/tts/pocket_tts/coreml/convert_models/convert/convert_cond_step.py
@@ -35,10 +35,26 @@ def convert(language: str, compute_precision: str = "fp16", compute_units: str =
     num_layers = cond_step.num_layers
     print(f"num_layers={num_layers}")
 
-    # Example inputs
-    conditioning = torch.randn(1, 1, 1024)
-    cache = torch.full((2, 1, 512, 16, 64), float('nan'))
-    pos = torch.zeros(1)
+    # Example inputs — mirror convert_flowlm_step.py's pattern: a partially
+    # populated cache (real fp32 values in the prefix, zeros after) plus a
+    # mid-cache position. The previous recipe traced with an all-NaN cache
+    # at position 0 (`valid_len = pos + 1 = 1`), which collapses the
+    # attention mask to a single position and lets coremltools' MIL
+    # optimizer fold trace-specific shortcuts (constant softmax, dead
+    # `where(isnan,...)` branches) into the graph. Runtime invocations at
+    # `pos > 0` then take the wrong code path and accumulate drift across
+    # the 100+ iterations of v1 voice/text prefill.
+    B = 1
+    T = 1
+    H = 16
+    D = 64
+    max_seq_len = 512
+    trace_pos = 100  # arbitrary mid-cache position; matches flowlm trace style
+
+    conditioning = torch.randn(B, T, 1024)
+    cache = torch.zeros(2, B, max_seq_len, H, D)
+    cache[:, :, :trace_pos, :, :] = torch.randn(2, B, trace_pos, H, D)
+    pos = torch.tensor([float(trace_pos)])
 
     example_inputs_list = [conditioning]
     for _ in range(num_layers):

--- a/models/tts/pocket_tts/coreml/convert_models/convert/convert_mimi_encoder.py
+++ b/models/tts/pocket_tts/coreml/convert_models/convert/convert_mimi_encoder.py
@@ -1,0 +1,197 @@
+"""Convert Mimi audio encoder (stateless) to CoreML.
+
+Traces `TraceableMimiEncoder` (encoder + encoder_transformer + _to_framerate
++ speaker_proj linear) against pocket-tts >= 2.0.0 weights and writes a
+CoreML mlpackage.
+
+Input:  audio        [1, 1, 240_000]  float32 (10s @ 24kHz, exactly 125 frames)
+Output: conditioning [1, 125, 1024]   float32 (one row per 80ms frame)
+
+This is the encoder counterpart to the deployed Apr 27 cond_step /
+flowlm_step / flow_decoder mlpackages. The legacy
+`voice_cloning/mimi_encoder.mlmodelc` was traced against a pre-2.0.0
+pocket-tts and produces conditioning in the wrong latent space for the
+deployed cond_step weights, causing immediate EOS (silent / garbled audio
+— FluidAudio issue #592). Re-tracing here restores the pure-CoreML voice
+cloning path (`export_voice_coreml.py`).
+"""
+import argparse
+import os
+import sys
+
+import coremltools as ct
+import numpy as np
+import torch
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_CONVERT_MODELS_DIR = os.path.dirname(_SCRIPT_DIR)
+_COREML_DIR = os.path.dirname(_CONVERT_MODELS_DIR)
+# NOTE: do NOT inject the parent pocket_tts/ directory onto sys.path. The
+# local checkout under `mobius/models/tts/pocket_tts/pocket_tts/` is the
+# 1.0.3-era source and would shadow the pip-installed `pocket-tts==2.0.0`
+# whose weights the deployed mlpackages were traced against. Rely solely on
+# the active venv to provide `pocket_tts` (`pip install 'pocket-tts==2.0.0'`).
+sys.path.insert(0, _SCRIPT_DIR)
+sys.path.insert(0, os.path.join(_CONVERT_MODELS_DIR, "traceable"))
+
+from _language_arg import (
+    add_compute_args,
+    add_language_arg,
+    build_output_dir,
+    resolve_compute_precision,
+    resolve_compute_units,
+)
+from traceable_mimi_encoder import (
+    AUDIO_LENGTH_SAMPLES,
+    EMBEDDING_DIM,
+    NUM_FRAMES,
+    TraceableMimiEncoder,
+)
+
+
+def rename_single_output(mlpackage_path: str, desired_name: str) -> None:
+    """Rename the auto-generated output (e.g. `var_NNN`/`castN`) to `desired_name`.
+
+    `ct.convert(..., outputs=[ct.TensorType(dtype=np.float32)])` leaves the
+    sole output with an anonymous SSA-derived name. The Swift loader needs
+    a stable semantic name (`conditioning`).
+    """
+    mlmodel = ct.models.MLModel(mlpackage_path, compute_units=ct.ComputeUnit.CPU_AND_GPU)
+    spec = mlmodel.get_spec()
+
+    output_names = [out.name for out in spec.description.output]
+    if len(output_names) != 1:
+        raise RuntimeError(
+            f"Expected exactly 1 output, found {len(output_names)}: {output_names}"
+        )
+
+    current = output_names[0]
+    if current == desired_name:
+        print(f"Output already named '{desired_name}'; nothing to rename.")
+        return
+
+    print(f"Renaming output: {current} -> {desired_name}")
+    ct.utils.rename_feature(
+        spec, current, desired_name, rename_inputs=False, rename_outputs=True
+    )
+
+    weights_dir = os.path.join(mlpackage_path, "Data", "com.apple.CoreML", "weights")
+    updated = ct.models.MLModel(
+        spec, weights_dir=weights_dir, compute_units=ct.ComputeUnit.CPU_AND_GPU
+    )
+    updated.save(mlpackage_path)
+
+
+def force_fp32_output_dtype(mlpackage_path: str) -> None:
+    """Flip the multiArray output's `dataType` from FLOAT16 to FLOAT32.
+
+    With `compute_precision=fp16` the internal MIL function produces fp16
+    values; the boundary cast op inserted by `ct.convert` already promotes
+    to fp32, but the spec's port dtype enum may still read FLOAT16. Force
+    it to FLOAT32 so Swift `MLMultiArray` allocations stay fp32-friendly
+    (the macOS MLE5 binder rejects fp16 buffers from Swift heap allocs).
+    """
+    from coremltools.proto import FeatureTypes_pb2 as _ft
+
+    FLOAT32 = _ft.ArrayFeatureType.FLOAT32
+    FLOAT16 = _ft.ArrayFeatureType.FLOAT16
+
+    mlmodel = ct.models.MLModel(mlpackage_path, compute_units=ct.ComputeUnit.CPU_AND_GPU)
+    spec = mlmodel.get_spec()
+
+    flipped = []
+    for out in spec.description.output:
+        if not out.type.HasField("multiArrayType"):
+            continue
+        if out.type.multiArrayType.dataType == FLOAT16:
+            out.type.multiArrayType.dataType = FLOAT32
+            flipped.append(out.name)
+
+    if not flipped:
+        print("All multiArray outputs already FLOAT32; nothing to flip.")
+        return
+
+    print(f"Flipping {len(flipped)} output dtype(s) FLOAT16 -> FLOAT32: {flipped}")
+    weights_dir = os.path.join(mlpackage_path, "Data", "com.apple.CoreML", "weights")
+    updated = ct.models.MLModel(
+        spec, weights_dir=weights_dir, compute_units=ct.ComputeUnit.CPU_AND_GPU
+    )
+    updated.save(mlpackage_path)
+
+
+def convert(language: str, compute_precision: str = "fp16", compute_units: str = "ALL") -> str:
+    print(f"Loading PocketTTS model (language={language})...")
+    from pocket_tts import TTSModel
+
+    model = TTSModel.load_model(language=language, lsd_decode_steps=8)
+    model.eval()
+
+    print("Creating traceable Mimi encoder...")
+    traceable = TraceableMimiEncoder.from_tts_model(model)
+    traceable.eval()
+
+    print(f"Tracing on fixed input shape (1, 1, {AUDIO_LENGTH_SAMPLES})...")
+    example_audio = torch.zeros(1, 1, AUDIO_LENGTH_SAMPLES)
+    with torch.no_grad():
+        traced = torch.jit.trace(traceable, (example_audio,), strict=False)
+
+    # Anonymous output spec (renamed below) — naming here would alias an
+    # internal SSA value and force a graph rewrite; matching the
+    # decoder converter's pattern instead.
+    ct_inputs = [ct.TensorType(name="audio", shape=(1, 1, AUDIO_LENGTH_SAMPLES), dtype=np.float32)]
+    ct_outputs = [ct.TensorType(dtype=np.float32)]
+
+    print(
+        f"Converting to CoreML (precision={compute_precision}, "
+        f"inputs=fp32, outputs=fp32 via cast op)..."
+    )
+    mlmodel = ct.convert(
+        traced,
+        inputs=ct_inputs,
+        outputs=ct_outputs,
+        minimum_deployment_target=ct.target.iOS17,
+        compute_precision=resolve_compute_precision(compute_precision),
+    )
+
+    output_dir = build_output_dir(_COREML_DIR, language)
+    os.makedirs(output_dir, exist_ok=True)
+    output_path = os.path.join(output_dir, "mimi_encoder.mlpackage")
+    print(f"Saving to {output_path}...")
+    mlmodel.save(output_path)
+
+    rename_single_output(output_path, "conditioning")
+    force_fp32_output_dtype(output_path)
+
+    # Reload for the post-save smoke test.
+    mlmodel = ct.models.MLModel(output_path, compute_units=resolve_compute_units(compute_units))
+    spec = mlmodel.get_spec()
+
+    print(f"\n=== INPUTS ({len(spec.description.input)}) ===")
+    for inp in spec.description.input:
+        if inp.type.HasField("multiArrayType"):
+            print(f"  {inp.name}: {list(inp.type.multiArrayType.shape)}")
+
+    print(f"\n=== OUTPUTS ({len(spec.description.output)}) ===")
+    for out in spec.description.output:
+        if out.type.HasField("multiArrayType"):
+            print(f"  {out.name}: {list(out.type.multiArrayType.shape)}")
+
+    print("\nRunning inference smoke test on zero audio...")
+    test_audio = np.zeros((1, 1, AUDIO_LENGTH_SAMPLES), dtype=np.float32)
+    out = mlmodel.predict({"audio": test_audio})
+    cond = out["conditioning"]
+    print(f"  conditioning: shape={cond.shape} dtype={cond.dtype} std={cond.std():.6f}")
+    assert cond.shape == (1, NUM_FRAMES, EMBEDDING_DIM), (
+        f"Unexpected output shape {cond.shape}, expected (1, {NUM_FRAMES}, {EMBEDDING_DIM})"
+    )
+
+    print("\nDone!")
+    return output_path
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    add_language_arg(parser)
+    add_compute_args(parser)
+    args = parser.parse_args()
+    convert(args.language, args.compute_precision, args.compute_units)

--- a/models/tts/pocket_tts/coreml/convert_models/traceable/traceable_mimi_encoder.py
+++ b/models/tts/pocket_tts/coreml/convert_models/traceable/traceable_mimi_encoder.py
@@ -1,0 +1,177 @@
+"""Traceable Mimi audio encoder for CoreML conversion.
+
+Wraps pocket-tts 2.0.0's audio-to-conditioning pipeline (TTSModel._encode_audio)
+into a torch.jit.traceable module so it can be converted to a CoreML
+mlpackage for voice cloning at runtime.
+
+Pipeline (stateless one-shot encode):
+    audio [1, 1, T] -> mimi.encoder           -> [1, 512, num_frames]
+                    -> mimi.encoder_transformer -> [1, 512, num_frames]
+                    -> mimi._to_framerate     -> [1,  32, num_frames]
+                    -> transpose(-1, -2)      -> [1, num_frames, 32]
+                    -> F.linear(speaker_proj) -> [1, num_frames, 1024]
+
+For tracing we fix `T = 125 * frame_size = 240_000` samples (10s at 24kHz,
+which is the standard PocketTTS voice prompt length). Callers that have
+shorter/longer audio must pad/truncate to exactly 240_000 samples before
+invoking the CoreML model.
+
+Why we need this re-trace
+-------------------------
+The legacy `voice_cloning/mimi_encoder.mlmodelc` shipped under PocketTTS was
+traced against a pocket-tts version older than the Apr 27 cond_step /
+flowlm_step / flow_decoder mlpackages now deployed under `build/<lang>/`.
+That older encoder maps audio to a conditioning latent space that disagrees
+with the new cond_step weights, causing the flow LM to emit EOS within a
+few steps (silent / garbled audio — FluidAudio issue #592). Re-tracing
+against pocket-tts 2.0.0 (the version that produced the deployed v2 caches)
+restores the correct latent space and unblocks the pure-CoreML voice
+cloning path.
+
+Tracing notes
+-------------
+The trace path is intentionally simpler than the decoder's:
+1. **No state I/O** — `mimi.encode_to_latent(audio, model_state=None)` runs
+   in stateless one-shot mode; per-layer streaming caches are initialized
+   and discarded inside the call. Inputs: 1 (audio). Outputs: 1 (cond).
+2. **`pad_for_conv1d` bypass** — upstream's pad helper goes through
+   `get_extra_padding_for_conv1d` which is `@beartype`'d to return `int`.
+   `torch.jit.trace` rewrites the return as a 0-d tensor; beartype then
+   throws `BeartypeCallHintReturnViolation`. We replace
+   `pocket_tts.models.mimi.pad_for_conv1d` with the identity (caller has
+   already aligned the audio length to a multiple of `frame_size`).
+3. **`init_state` beartype unwrap** — `StreamingConv1d.init_state` /
+   `StreamingConvTranspose1d.init_state` are `@beartype`'d on
+   `batch_size: int`; trace passes a 0-d tensor here too. Replace with the
+   `__wrapped__` originals.
+4. **In-place op patches** — reuse `traceable_mimi_decoder._patch_for_tracing`
+   to swap `StreamingConv1d.forward`, `StreamingConvTranspose1d.forward`,
+   and `StreamingMultiheadAttention.forward` with functional versions
+   (`torch.jit.trace` can't capture `state[:] = ...` writes).
+"""
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+# Fixed shapes for the traced model.
+# 125 * 1920 = 240_000 samples = 10s at 24kHz, matching PocketTTS's
+# `VOICE_PROMPT_LENGTH = 125` convention.
+AUDIO_LENGTH_SAMPLES = 125 * 1920
+NUM_FRAMES = 125
+EMBEDDING_DIM = 1024
+
+
+def _patch_beartype_unwrap_init_state():
+    """Replace `@beartype`-decorated `init_state` methods with their __wrapped__.
+
+    Required because torch.jit.trace passes a 0-d tensor for `batch_size`,
+    which beartype rejects at runtime.
+    """
+    import pocket_tts.modules.conv as conv_mod
+
+    for cls in (conv_mod.StreamingConv1d, conv_mod.StreamingConvTranspose1d):
+        fn = getattr(cls, "init_state", None)
+        if fn is not None and hasattr(fn, "__wrapped__"):
+            setattr(cls, "init_state", fn.__wrapped__)
+
+
+def _patch_pad_for_conv1d_identity():
+    """Replace `pad_for_conv1d` with identity on the mimi module path.
+
+    `pad_for_conv1d` calls `get_extra_padding_for_conv1d` which is
+    beartype'd to return `int`; trace converts the return to a 0-d tensor
+    and the type check fails. Since our trace input length is already a
+    multiple of `frame_size`, padding is a no-op.
+    """
+    import pocket_tts.models.mimi as mimi_mod
+
+    mimi_mod.pad_for_conv1d = lambda x, k, s: x
+
+
+def patch_mimi_for_encoder_tracing(mimi):
+    """Apply all monkey-patches needed to trace `mimi.encode_to_latent`.
+
+    Reuses the in-place op patches from `traceable_mimi_decoder` and adds
+    the beartype unwraps + pad bypass specific to the encoder path.
+    Idempotent — safe to call multiple times.
+    """
+    from traceable_mimi_decoder import _patch_for_tracing
+
+    _patch_for_tracing(mimi)
+    _patch_beartype_unwrap_init_state()
+    _patch_pad_for_conv1d_identity()
+
+
+class TraceableMimiEncoder(nn.Module):
+    """Stateless audio-to-conditioning wrapper for CoreML tracing.
+
+    Input:  audio        [1, 1, AUDIO_LENGTH_SAMPLES] float32
+    Output: conditioning [1, NUM_FRAMES, EMBEDDING_DIM] float32
+
+    The output matches `TTSModel._encode_audio(audio.unsqueeze(0))`
+    bit-for-bit (within fp32 rounding) after `patch_mimi_for_encoder_tracing`.
+    """
+
+    def __init__(self, mimi_model, speaker_proj_weight: torch.Tensor):
+        super().__init__()
+        self.mimi = mimi_model
+        self.register_buffer("speaker_proj_weight", speaker_proj_weight)
+        patch_mimi_for_encoder_tracing(self.mimi)
+
+    @classmethod
+    def from_tts_model(cls, tts_model) -> "TraceableMimiEncoder":
+        return cls(
+            mimi_model=tts_model.mimi,
+            speaker_proj_weight=tts_model.flow_lm.speaker_proj_weight,
+        )
+
+    def forward(self, audio: torch.Tensor) -> torch.Tensor:
+        # Inline `mimi.encode_to_latent` minus `pad_for_conv1d` (handled by
+        # the caller via fixed input length).
+        emb = self.mimi.encoder(audio, model_state=None)
+        (emb,) = self.mimi.encoder_transformer(emb, model_state=None)
+        emb = self.mimi._to_framerate(emb)  # [1, 32, NUM_FRAMES]
+        latents = emb.transpose(-1, -2).to(torch.float32)  # [1, NUM_FRAMES, 32]
+        conditioning = F.linear(latents, self.speaker_proj_weight)  # [1, NUM_FRAMES, 1024]
+        return conditioning
+
+
+def test_traceable_mimi_encoder():
+    import os
+    import sys
+
+    _script_dir = os.path.dirname(os.path.abspath(__file__))
+    sys.path.insert(0, _script_dir)
+
+    from pocket_tts import TTSModel
+
+    print("Loading TTSModel...")
+    model = TTSModel.load_model(language="english", lsd_decode_steps=8)
+    model.eval()
+
+    print("Creating traceable encoder...")
+    wrap = TraceableMimiEncoder.from_tts_model(model)
+    wrap.eval()
+
+    audio = torch.zeros(1, 1, AUDIO_LENGTH_SAMPLES)
+    with torch.no_grad():
+        cond = wrap(audio)
+    print(f"Forward output: shape={tuple(cond.shape)} dtype={cond.dtype}")
+    assert tuple(cond.shape) == (1, NUM_FRAMES, EMBEDDING_DIM)
+
+    print("Tracing...")
+    with torch.no_grad():
+        traced = torch.jit.trace(wrap, (audio,), strict=False)
+    print("Trace succeeded.")
+
+    with torch.no_grad():
+        traced_cond = traced(audio)
+    print(f"Traced output: shape={tuple(traced_cond.shape)}")
+    diff = (traced_cond - cond).abs().max().item()
+    print(f"Max diff (traced vs eager): {diff:.2e}")
+
+
+if __name__ == "__main__":
+    test_traceable_mimi_encoder()

--- a/models/tts/pocket_tts/coreml/generate_coreml_v4.py
+++ b/models/tts/pocket_tts/coreml/generate_coreml_v4.py
@@ -344,6 +344,15 @@ def generate_v4(
     # the legacy emb_mean / emb_std / quantizer_weight / mimi_init_state
     # files are no longer consumed.
     bos_emb = np.load(os.path.join(const_dir, "bos_emb.npy"))
+    # bos_before_voice is prepended to the v1 audio_prompt during cond_step
+    # prefill (matches pocket-tts 2.0.0's `flow_lm.bos_before_voice`). Without
+    # it the cond_step output diverges from the deployed v2 cache state and
+    # the flow LM emits EOS within a few steps (silent / garbled audio).
+    # v2 voices have this token already baked into their KV state.
+    bos_before_voice_path = os.path.join(const_dir, "bos_before_voice.npy")
+    bos_before_voice = (
+        np.load(bos_before_voice_path) if os.path.isfile(bos_before_voice_path) else None
+    )
 
     # 6. Load CoreML models — per-model compute-unit strategy (profiled M-series, FP16):
     #
@@ -437,10 +446,18 @@ def generate_v4(
                 (2, 1, cache_slots, 16, 64), dtype=np.float32
             )
             positions[f'position{i}'] = np.array([0.0], dtype=np.float32)
-        prefill_tokens = np.concatenate([voice_emb_v1, text_emb], axis=1)
+        if bos_before_voice is None:
+            raise FileNotFoundError(
+                f"Missing {bos_before_voice_path}. The v1 cond_step prefill path "
+                "requires the bos_before_voice constant (pocket-tts 2.0.0's "
+                "`flow_lm.bos_before_voice`). Regenerate it with "
+                "coreml/voice_cloning/export_constants.py or switch the voice to v2."
+            )
+        bos_voice_text = [bos_before_voice, voice_emb_v1, text_emb]
+        prefill_tokens = np.concatenate(bos_voice_text, axis=1).astype(np.float32)
         print(
             f"Conditioning: {prefill_tokens.shape[1]} tokens "
-            f"(voice={voice_emb_v1.shape[1]}, text={text_emb.shape[1]})"
+            f"(bos=1, voice={voice_emb_v1.shape[1]}, text={text_emb.shape[1]})"
         )
 
     # 9. Prefill remaining conditioning tokens (v2: text only; v1: voice+text).

--- a/models/tts/pocket_tts/coreml/voice_cloning/README.md
+++ b/models/tts/pocket_tts/coreml/voice_cloning/README.md
@@ -2,35 +2,60 @@
 
 Export custom voices for use with FluidAudio's PocketTTS Swift implementation.
 
+> **Two equivalent paths** as of 2026-05-11:
+>
+> - `export_voice_v2.py` — PyTorch pipeline, bakes a v2 KV-cache
+>   `.safetensors` (drop-in for `build/<lang>/constants_bin/`). Requires
+>   `pip install pocket-tts==2.0.0`.
+> - `export_voice_coreml.py` — pure CoreML pipeline, writes a v1
+>   `<voice>_audio_prompt.bin` consumed by `generate_coreml_v4.py`'s v1
+>   `cond_step` prefill path. Requires the retraced
+>   `mimi_encoder.mlpackage` produced by
+>   `convert_models/convert/convert_mimi_encoder.py`.
+>
+> Both produce intelligible speech against the deployed Apr 27 cond_step /
+> flowlm_step / flow_decoder mlpackages. Pick `export_voice_v2.py` when you
+> want PyTorch parity (e.g. matching deployed voice caches bit-for-bit) and
+> `export_voice_coreml.py` when you want a Python toolchain without
+> PyTorch + pocket-tts installed.
+>
+> Historical note (FluidAudio #592): the originally shipped
+> `mimi_encoder.mlmodelc` was traced against a pre-2.0.0 pocket-tts and
+> produced conditioning in the wrong latent space, causing immediate EOS.
+> The new mlpackage built from `convert_mimi_encoder.py` fixes that, and
+> the v1 `generate_coreml_v4.py` cond_step path now also prepends the
+> required `bos_before_voice` token.
+
 ## Quick Start
 
 ```bash
 cd mobius/models/tts/pocket_tts
 
-# Install dependencies
-pip install torch safetensors torchaudio
+# Install pocket-tts 2.0.0 (must match the deployed mlpackage trace)
+pip install "pocket-tts==2.0.0" safetensors torch
 
-# Export a voice from audio file
-python coreml/export_voice_coreml.py your_voice.wav -o constants_bin/custom_audio_prompt.bin
-
-# The output file can be used with FluidAudio
+# Bake a v2 KV-cache voice file (drop-in for build/<lang>/constants_bin/)
+python coreml/voice_cloning/export_voice_v2.py \
+    your_voice.wav \
+    -o build/english/constants_bin/your_voice.safetensors
 ```
 
 ## Full Workflow: Export → Test → Evaluate
 
 ```bash
-# One command does it all: export voice, run CoreML inference, evaluate
-python coreml/test_voice_coreml.py \
-    --reference speaker.wav \
-    --text "Hello, this is a voice cloning test." \
-    --output test_output.wav \
-    --evaluate
-```
+# 1. Bake voice as v2 KV-cache.
+python coreml/voice_cloning/export_voice_v2.py speaker.wav \
+    -o build/english/constants_bin/speaker.safetensors
 
-This will:
-1. Export the voice from `speaker.wav` → `speaker_audio_prompt.bin`
-2. Run CoreML TTS with the exported voice
-3. Evaluate spectral similarity against reference
+# 2. Run the CoreML pipeline against the freshly baked voice.
+python coreml/generate_coreml_v4.py \
+    --language english --voice speaker \
+    --text "Hello, this is a voice cloning test." \
+    --output test_output.wav
+
+# 3. (Optional) Speaker similarity vs reference.
+python coreml/voice_cloning/evaluate_voice.py speaker.wav test_output.wav
+```
 
 ## Testing Exported Voices
 
@@ -55,8 +80,33 @@ python coreml/test_voice_coreml.py \
 
 2. **Python dependencies**:
    ```bash
-   pip install torch safetensors torchaudio
+   pip install "pocket-tts==2.0.0" safetensors torch
    ```
+
+   `pocket-tts` 2.0.0 (released 2026-04-21) is the exact library that traced
+   the deployed `cond_step.mlpackage` / `flowlm_step.mlpackage` /
+   `flow_decoder_fused8.mlpackage`. Newer 2.x versions should also work; the
+   1.x line is incompatible (different HF revision + repo path layout).
+
+## Pure-CoreML export with `export_voice_coreml.py`
+
+The mlpackage shipped originally as `mimi_encoder.mlmodelc` was traced from a
+pre-2.0.0 pocket-tts revision and produced conditioning in a latent space
+incompatible with the deployed cond_step (FluidAudio #592 — immediate EOS).
+Re-trace the encoder against pocket-tts 2.0.0 first:
+
+```bash
+# Bake a fresh mlpackage from pocket-tts 2.0.0 weights into
+# coreml/build/<lang>/mimi_encoder.mlpackage and symlink it into voice_cloning/.
+python coreml/convert_models/convert/convert_mimi_encoder.py --language english
+ln -sfn ../build/english/mimi_encoder.mlpackage \
+    coreml/voice_cloning/mimi_encoder.mlpackage
+```
+
+After that, `export_voice_coreml.py` writes a v1
+`<voice>_audio_prompt.bin` that pairs with the patched
+`generate_coreml_v4.py` v1 prefill path (which now prepends the required
+`bos_before_voice` token).
 
 ## Usage
 

--- a/models/tts/pocket_tts/coreml/voice_cloning/export_voice_coreml.py
+++ b/models/tts/pocket_tts/coreml/voice_cloning/export_voice_coreml.py
@@ -35,6 +35,13 @@ FRAME_SIZE = 1920  # 80ms frames
 VOICE_PROMPT_LENGTH = 125  # Standard voice prompt length
 EMBEDDING_DIM = 1024
 
+# The mimi_encoder.mlpackage produced by `convert_mimi_encoder.py` was traced
+# with a fixed audio input length of VOICE_PROMPT_LENGTH * FRAME_SIZE = 240_000
+# samples (10s @ 24kHz). The original mlmodelc accepted variable-length input,
+# so we pad/truncate here so the same Python entry point works against both
+# encoders.
+ENCODER_INPUT_SAMPLES = VOICE_PROMPT_LENGTH * FRAME_SIZE
+
 
 def load_audio(path: Path) -> np.ndarray:
     """Load and preprocess audio for the encoder."""
@@ -71,11 +78,17 @@ def load_audio(path: Path) -> np.ndarray:
 
 
 def pad_audio(audio: np.ndarray) -> np.ndarray:
-    """Pad audio to multiple of frame size."""
+    """Pad or truncate audio to ENCODER_INPUT_SAMPLES (fixed CoreML input length).
+
+    The retraced mimi_encoder.mlpackage requires exactly
+    `VOICE_PROMPT_LENGTH * FRAME_SIZE = 240_000` samples (10s @ 24kHz). Shorter
+    clips are right-padded with zeros, longer clips are truncated.
+    """
     length = len(audio)
-    pad_length = (FRAME_SIZE - (length % FRAME_SIZE)) % FRAME_SIZE
-    if pad_length > 0:
-        audio = np.pad(audio, (0, pad_length))
+    if length < ENCODER_INPUT_SAMPLES:
+        audio = np.pad(audio, (0, ENCODER_INPUT_SAMPLES - length))
+    elif length > ENCODER_INPUT_SAMPLES:
+        audio = audio[:ENCODER_INPUT_SAMPLES]
     return audio
 
 

--- a/models/tts/pocket_tts/coreml/voice_cloning/export_voice_v2.py
+++ b/models/tts/pocket_tts/coreml/voice_cloning/export_voice_v2.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Export a voice as a v2 KV-cache safetensors file using pocket-tts >= 2.0.0.
+
+Why this exists
+---------------
+The legacy ``export_voice_coreml.py`` runs a CoreML ``mimi_encoder.mlmodelc``
+that was traced against a pocket-tts version older than the Apr 27 cond_step /
+flowlm_step / flow_decoder mlpackages now deployed under ``build/<lang>/``.
+That mismatch produces a ``*_audio_prompt.bin`` whose conditioning latent space
+disagrees with the new cond_step weights; feeding it through the v1 prefill
+path causes the flow LM to emit EOS within a handful of steps (silent or
+garbled output — FluidAudio issue #592).
+
+This script side-steps the broken CoreML encoder by running the *exact* PyTorch
+pipeline that produced the deployed v2 caches: pocket-tts 2.0.0's
+``TTSModel.get_state_for_audio_prompt`` (encode mimi -> project -> bos prefix
+-> cond_step prefill -> capture KV state). The output is a v2 KV-cache
+safetensors with shape ``[2, 1, prompt_len, 16, 64]`` per layer plus
+``[prompt_len]`` offsets, drop-in compatible with
+``_locate_voice_v2`` in ``generate_coreml_v4.py`` and with FluidAudio's Swift
+runtime once a v2 loader is in place.
+
+Requirements
+------------
+    pip install "pocket-tts==2.0.0"
+
+(or 2.1.0; do **not** use the local 1.0.3-era ``pocket_tts/`` directory in
+this repo — it pins a different HF revision and predates the deployed
+mlpackage trace.)
+
+Usage
+-----
+    python export_voice_v2.py speaker.wav -o build/english/constants_bin/speaker.safetensors
+    python export_voice_v2.py speaker.wav --name speaker --output-dir build/english/constants_bin/
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import torch
+from safetensors.torch import save_file
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def _require_pocket_tts_2x():
+    try:
+        from pocket_tts import TTSModel  # noqa: F401
+        from pocket_tts.models.tts_model import init_states  # noqa: F401
+        from pocket_tts.models.tts_model import audio_read, convert_audio  # noqa: F401
+        from pocket_tts.utils.utils import get_predefined_voice  # noqa: F401
+    except ImportError as exc:
+        raise SystemExit(
+            f"pocket-tts >= 2.0.0 is required (got import error: {exc}). "
+            "Install with: pip install 'pocket-tts==2.0.0'"
+        ) from exc
+
+
+def export_voice(wav: Path, out: Path, language: str, lsd_decode_steps: int) -> None:
+    _require_pocket_tts_2x()
+    from pocket_tts import TTSModel
+    from pocket_tts.models.tts_model import init_states, audio_read, convert_audio
+
+    logger.info("Loading TTSModel (language=%s)...", language)
+    model = TTSModel.load_model(language=language, lsd_decode_steps=lsd_decode_steps)
+    model.eval()
+
+    logger.info("Reading %s", wav)
+    audio, sr = audio_read(str(wav))
+    logger.info("  raw: shape=%s sr=%d", tuple(audio.shape), sr)
+    audio = convert_audio(audio, sr, model.config.mimi.sample_rate, 1)
+    logger.info("  resampled: shape=%s sr=%d", tuple(audio.shape), model.config.mimi.sample_rate)
+
+    with torch.no_grad():
+        audio_prompt = model._encode_audio(audio.unsqueeze(0).to(model.device))
+    logger.info("  audio_prompt: shape=%s std=%.4f", tuple(audio_prompt.shape), audio_prompt.std().item())
+
+    prompt = audio_prompt
+    if model.flow_lm.insert_bos_before_voice:
+        prompt = torch.cat([model.flow_lm.bos_before_voice, prompt], dim=1)
+
+    with torch.no_grad():
+        state = init_states(model.flow_lm, batch_size=1, sequence_length=prompt.shape[1])
+        model._run_flow_lm_and_increment_step(model_state=state, audio_conditioning=prompt)
+
+    flat: dict[str, torch.Tensor] = {}
+    layer_keys = sorted(
+        (k for k in state if ".self_attn" in k and "transformer.layers." in k),
+        key=lambda k: int(k.split(".layers.")[1].split(".")[0]),
+    )
+    if len(layer_keys) == 0:
+        raise RuntimeError("No transformer.layers.*.self_attn entries in model_state; pocket-tts API changed?")
+
+    for lk in layer_keys:
+        s = state[lk]
+        flat[f"{lk}/cache"] = s["cache"].to(torch.float32).contiguous().cpu()
+        flat[f"{lk}/offset"] = s["offset"].to(torch.int64).contiguous().cpu()
+
+    prompt_len = int(flat[layer_keys[0] + "/offset"].item())
+    cache_std = flat[layer_keys[0] + "/cache"].std().item()
+    logger.info("  baked cache: layers=%d prompt_len=%d L0_std=%.4f", len(layer_keys), prompt_len, cache_std)
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    save_file(flat, str(out))
+    logger.info("Wrote %s (%d bytes)", out, out.stat().st_size)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="Bake a v2 KV-cache safetensors voice file from an audio sample.",
+    )
+    p.add_argument("wav", type=Path, help="Source audio file (wav/mp3/flac/...).")
+    p.add_argument(
+        "-o", "--output", type=Path, default=None,
+        help="Output .safetensors path. Mutually exclusive with --output-dir.",
+    )
+    p.add_argument(
+        "--output-dir", type=Path, default=None,
+        help="Output directory; filename derived from --name or wav stem.",
+    )
+    p.add_argument(
+        "--name", type=str, default=None,
+        help="Voice name for filename when using --output-dir (default: wav stem).",
+    )
+    p.add_argument(
+        "--language", type=str, default="english",
+        help="pocket-tts language config (default: english; = english_2026-04 in 2.0.0).",
+    )
+    p.add_argument(
+        "--lsd-decode-steps", type=int, default=8,
+        help="LSD decode steps for model load (default: 8, matches deployed pipeline).",
+    )
+    args = p.parse_args()
+
+    if not args.wav.is_file():
+        logger.error("Input not found: %s", args.wav)
+        sys.exit(1)
+
+    if args.output is None and args.output_dir is None:
+        logger.error("Specify either --output or --output-dir.")
+        sys.exit(2)
+    if args.output is not None and args.output_dir is not None:
+        logger.error("--output and --output-dir are mutually exclusive.")
+        sys.exit(2)
+
+    if args.output is not None:
+        out = args.output
+    else:
+        name = args.name or args.wav.stem
+        out = args.output_dir / f"{name}.safetensors"
+
+    export_voice(args.wav, out, args.language, args.lsd_decode_steps)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fixes [FluidAudio #592](https://github.com/FluidInference/FluidAudio/issues/592) — PocketTTS voice cloning produced garbled / silent audio on macOS while built-in voices worked.

The deployed `cond_step` / `flowlm_step` / `flow_decoder` mlpackages under `build/<lang>/` were traced against `pocket-tts == 2.0.0` (Apr 27), but two adjacent artifacts still encoded an older revision and broke voice cloning end-to-end.

### Root causes

1. **Missing `bos_before_voice` token** in `generate_coreml_v4.py`'s v1 prefill. pocket-tts 2.0.0 prepends `flow_lm.bos_before_voice` (a 1024-dim BOS token) before running cond_step; the CoreML path concatenated only `[voice_emb, text_emb]`. Without the BOS prefix the cond_step output diverges from the deployed v2 cache state and the flow LM emits EOS within a few steps.

2. **Legacy `voice_cloning/mimi_encoder.mlmodelc`** was traced from a pre-2.0.0 pocket-tts; conditioning lands in the wrong latent space for the deployed cond_step weights. Any `*_audio_prompt.bin` it produced was effectively poison.

3. **`convert_cond_step.py` trace recipe** used `pos = 0` with an all-NaN cache, which collapses the attention mask to a single position and lets coremltools' MIL optimizer fold trace-specific shortcuts (constant softmax, dead `where(isnan,...)` branches). Runtime calls at `pos > 0` took the wrong code path and accumulated drift across the 100+ v1 prefill iterations.

### Changes

| Path | Change |
|------|--------|
| `coreml/generate_coreml_v4.py` | Load `bos_before_voice.npy`, prepend to v1 prefill `[bos, voice, text]`. Hard error if constant missing. |
| `coreml/convert_models/traceable/traceable_mimi_encoder.py` *(new)* | Fixed-shape `[1, 1, 240_000] -> [1, 125, 1024]` wrapper around `mimi.encode_to_latent + transpose + speaker_proj`. Reuses decoder's in-place op patches, adds beartype unwraps for `StreamingConv1d.init_state` / `StreamingConvTranspose1d.init_state`, identity-replaces `pad_for_conv1d` (input is already aligned). |
| `coreml/convert_models/convert/convert_mimi_encoder.py` *(new)* | Single-IO conversion (fp32 IO, fp16 internal). Avoids `sys.path.insert(0, _PROJECT_DIR)` so the installed 2.0.0 isn't shadowed by the local 1.0.3 source. |
| `coreml/convert_models/convert/convert_cond_step.py` | Trace at mid-cache position (100) with partially populated cache, mirroring `convert_flowlm_step.py`. |
| `coreml/voice_cloning/export_voice_v2.py` *(new)* | PyTorch path that runs pocket-tts 2.0.0's `_run_flow_lm_and_increment_step` and writes a drop-in v2 KV-cache `.safetensors`. |
| `coreml/voice_cloning/export_voice_coreml.py` | Pad/truncate audio to fixed 240k-sample input expected by the retraced encoder. |
| `coreml/voice_cloning/README.md` | Document both export paths as working; drop the "known broken" warning. |

### Numerical parity

- Traced encoder vs PyTorch `_encode_audio`: `max_diff = 3e-7` (fp32 noise).
- `export_voice_v2.py` vs deployed v2 caches across 21 voices: 13 bit-identical, 8 with `~3e-2` drift (negligible).

## Test plan

- [x] `convert_mimi_encoder.py --language english` — succeeds; smoke test on zero input returns `(1, 125, 1024)`, `std=0.060`.
- [x] `export_voice_coreml.py am_michael.wav -o am_michael_audio_prompt.bin` — produces a 500 KB bin against the retraced encoder.
- [x] `generate_coreml_v4.py --voice am_michael_v2coreml --text "The quick brown fox..."` — 3.60s WAV, whisper transcript = "The quick brown fox jumps over the lazy dog."
- [x] Same flow via `export_voice_v2.py` -> `.safetensors` -> v2 prefill path: intelligible speech, whisper-confirmed.
- [ ] Re-trace `mimi_encoder.mlpackage` for the 9 non-English language packs (English-only for now; non-English packs run `convert_mimi_encoder.py --language <id>`).
- [ ] Wire the new mlpackage + `bos_before_voice.npy` into HuggingFace cache distribution (out of scope; left to release tooling).