### PR TITLE
feat(stt/nemotron-streaming): 2240ms tier + B1 fusion + encoder optimization sweep

### DIFF
--- a/models/stt/nemotron-speech-streaming-0.6b/coreml/bench_rtfx.py
+++ b/models/stt/nemotron-speech-streaming-0.6b/coreml/bench_rtfx.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""WER + RTFx benchmark for converted Nemotron streaming CoreML tiers.
+
+Reuses the streaming decode loop from test_coreml_streaming.py but loads the
+models on CPU_AND_NE (the ship config) and times wall-clock to report RTFx.
+"""
+import argparse
+import glob
+import time
+from pathlib import Path
+
+import coremltools as ct
+import numpy as np
+import soundfile as sf
+
+from test_coreml_streaming import NemotronCoreMLStreaming, load_ground_truth, compute_wer
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model-dir", required=True)
+    ap.add_argument("--dataset", required=True)
+    ap.add_argument("--num-files", type=int, default=100)
+    ap.add_argument("--warmup", type=int, default=3)
+    args = ap.parse_args()
+
+    inf = NemotronCoreMLStreaming(args.model_dir)
+    # Reload on CPU_AND_NE (ship config); the harness defaults to ALL.
+    md = Path(args.model_dir)
+    cu = ct.ComputeUnit.CPU_AND_NE
+    inf.preprocessor = ct.models.MLModel(str(md / "preprocessor.mlpackage"), compute_units=cu)
+    inf.encoder = ct.models.MLModel(str(md / "encoder.mlpackage"), compute_units=cu)
+    inf.decoder = ct.models.MLModel(str(md / "decoder.mlpackage"), compute_units=cu)
+    inf.joint = ct.models.MLModel(str(md / "joint.mlpackage"), compute_units=cu)
+
+    gt = load_ground_truth(args.dataset)
+    files = sorted(glob.glob(f"{args.dataset}/**/*.flac", recursive=True))[: args.num_files + args.warmup]
+
+    total_err = total_words = 0
+    audio_s = 0.0
+    compute_s = 0.0
+    n = 0
+    for i, path in enumerate(files):
+        fid = Path(path).stem
+        audio, sr = sf.read(path, dtype="float32")
+        t0 = time.perf_counter()
+        hyp = inf.transcribe_streaming(audio)
+        dt = time.perf_counter() - t0
+        if i < args.warmup:
+            continue
+        n += 1
+        audio_s += len(audio) / sr
+        compute_s += dt
+        if fid in gt:
+            e, w = compute_wer(gt[fid], hyp)
+            total_err += e
+            total_words += w
+        if n % 20 == 0:
+            print(f"  {n} files | WER {100*total_err/max(total_words,1):.2f}% | RTFx {audio_s/compute_s:.1f}")
+
+    wer = 100 * total_err / total_words if total_words else 0.0
+    print("=" * 60)
+    print(f"model-dir : {args.model_dir}")
+    print(f"chunk_mel : {inf.chunk_mel_frames} ({inf.chunk_mel_frames*10}ms)")
+    print(f"files     : {n}")
+    print(f"WER       : {wer:.2f}%")
+    print(f"audio_s   : {audio_s:.1f}  compute_s : {compute_s:.1f}")
+    print(f"RTFx      : {audio_s/compute_s:.1f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/stt/nemotron-speech-streaming-0.6b/coreml/bench_rtfx_fused.py
+++ b/models/stt/nemotron-speech-streaming-0.6b/coreml/bench_rtfx_fused.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""WER + RTFx benchmark for the B1-fused (decoder+joint) Nemotron streaming path.
+
+Same streaming/cache logic as test_coreml_streaming.py, but the inner decode loop
+makes ONE fused CoreML call (decoder_joint.mlpackage) per step instead of two.
+Argmax stays in Python (== Swift in the real pipeline). CPU_AND_NE (ship config).
+"""
+import argparse
+import glob
+import time
+from pathlib import Path
+
+import coremltools as ct
+import numpy as np
+import soundfile as sf
+
+from test_coreml_streaming import NemotronCoreMLStreaming, load_ground_truth, compute_wer
+
+
+class FusedStreaming(NemotronCoreMLStreaming):
+    def load_fused(self, model_dir):
+        md = Path(model_dir)
+        cu = ct.ComputeUnit.CPU_AND_NE
+        self.preprocessor = ct.models.MLModel(str(md / "preprocessor.mlpackage"), compute_units=cu)
+        self.encoder = ct.models.MLModel(str(md / "encoder.mlpackage"), compute_units=cu)
+        self.fused = ct.models.MLModel(str(md / "decoder_joint.mlpackage"), compute_units=cu)
+
+    def transcribe_streaming(self, audio: np.ndarray) -> str:
+        audio = audio.astype(np.float32)
+        total = len(audio)
+        cache_channel, cache_time, cache_len = self._get_initial_cache()
+        h, c = self._get_initial_decoder_state()
+        last_token = self.blank_idx
+        all_tokens = []
+        mel_cache = None
+        offset = 0
+        while offset < total:
+            end = min(offset + self.chunk_samples, total)
+            chunk = audio[offset:end]
+            if len(chunk) < self.chunk_samples:
+                chunk = np.pad(chunk, (0, self.chunk_samples - len(chunk)))
+            chunk = chunk.reshape(1, -1)
+            pre = self.preprocessor.predict({"audio": chunk, "audio_length": np.array([chunk.shape[1]], dtype=np.int32)})
+            cmel = pre["mel"]
+            if mel_cache is not None:
+                imel = np.concatenate([mel_cache, cmel], axis=2)
+            else:
+                imel = np.pad(cmel, ((0, 0), (0, 0), (self.pre_encode_cache, 0)), mode="constant")
+            cf = imel.shape[2]
+            if cf < self.total_mel_frames:
+                imel = np.pad(imel, ((0, 0), (0, 0), (0, self.total_mel_frames - cf)), mode="constant")
+            elif cf > self.total_mel_frames:
+                imel = imel[:, :, : self.total_mel_frames]
+            mel_cache = cmel[:, :, -self.pre_encode_cache:] if cmel.shape[2] >= self.pre_encode_cache else cmel
+
+            enc = self.encoder.predict({
+                "mel": imel.astype(np.float32), "mel_length": np.array([self.total_mel_frames], dtype=np.int32),
+                "cache_channel": cache_channel, "cache_time": cache_time, "cache_len": cache_len})
+            encoded = enc["encoded"]
+            cache_channel, cache_time, cache_len = enc["cache_channel_out"], enc["cache_time_out"], enc["cache_len_out"]
+
+            for t in range(encoded.shape[2]):
+                enc_step = encoded[:, :, t:t + 1].astype(np.float32)
+                for _ in range(10):
+                    out = self.fused.predict({
+                        "token": np.array([[last_token]], dtype=np.int32),
+                        "token_length": np.array([1], dtype=np.int32),
+                        "h_in": h, "c_in": c, "encoder": enc_step})
+                    pred = int(np.argmax(out["logits"][0, 0, 0, :]))
+                    if pred == self.blank_idx:
+                        break
+                    all_tokens.append(pred)
+                    last_token = pred
+                    h, c = out["h_out"], out["c_out"]
+            offset += self.chunk_samples
+        return self._decode_tokens(all_tokens)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model-dir", required=True)
+    ap.add_argument("--dataset", required=True)
+    ap.add_argument("--num-files", type=int, default=100)
+    ap.add_argument("--warmup", type=int, default=3)
+    args = ap.parse_args()
+
+    inf = FusedStreaming(args.model_dir)
+    inf.load_fused(args.model_dir)
+    gt = load_ground_truth(args.dataset)
+    files = sorted(glob.glob(f"{args.dataset}/**/*.flac", recursive=True))[: args.num_files + args.warmup]
+
+    te = tw = 0
+    audio_s = compute_s = 0.0
+    n = 0
+    for i, p in enumerate(files):
+        fid = Path(p).stem
+        a, sr = sf.read(p, dtype="float32")
+        t0 = time.perf_counter()
+        hyp = inf.transcribe_streaming(a)
+        dt = time.perf_counter() - t0
+        if i < args.warmup:
+            continue
+        n += 1
+        audio_s += len(a) / sr
+        compute_s += dt
+        if fid in gt:
+            e, w = compute_wer(gt[fid], hyp)
+            te += e
+            tw += w
+    print("=" * 60)
+    print(f"model-dir : {args.model_dir} (B1 fused decoder+joint)")
+    print(f"chunk_mel : {inf.chunk_mel_frames} ({inf.chunk_mel_frames*10}ms)")
+    print(f"files     : {n}")
+    print(f"WER       : {100*te/max(tw,1):.2f}%")
+    print(f"RTFx      : {audio_s/compute_s:.1f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/stt/nemotron-speech-streaming-0.6b/coreml/bench_rtfx_fused.py
+++ b/models/stt/nemotron-speech-streaming-0.6b/coreml/bench_rtfx_fused.py
@@ -22,7 +22,8 @@ class FusedStreaming(NemotronCoreMLStreaming):
         md = Path(model_dir)
         cu = ct.ComputeUnit.CPU_AND_NE
         self.preprocessor = ct.models.MLModel(str(md / "preprocessor.mlpackage"), compute_units=cu)
-        self.encoder = ct.models.MLModel(str(md / "encoder.mlpackage"), compute_units=cu)
+        ecu = getattr(ct.ComputeUnit, getattr(self,"_ecu","CPU_AND_NE"))
+        self.encoder = ct.models.MLModel(str(md / "encoder.mlpackage"), compute_units=ecu)
         self.fused = ct.models.MLModel(str(md / "decoder_joint.mlpackage"), compute_units=cu)
 
     def transcribe_streaming(self, audio: np.ndarray) -> str:
@@ -82,9 +83,11 @@ def main():
     ap.add_argument("--dataset", required=True)
     ap.add_argument("--num-files", type=int, default=100)
     ap.add_argument("--warmup", type=int, default=3)
+    ap.add_argument("--encoder-cu", default="CPU_AND_NE")
     args = ap.parse_args()
 
     inf = FusedStreaming(args.model_dir)
+    inf._ecu = args.encoder_cu
     inf.load_fused(args.model_dir)
     gt = load_ground_truth(args.dataset)
     files = sorted(glob.glob(f"{args.dataset}/**/*.flac", recursive=True))[: args.num_files + args.warmup]

--- a/models/stt/nemotron-speech-streaming-0.6b/coreml/bench_rtfx_sharded.py
+++ b/models/stt/nemotron-speech-streaming-0.6b/coreml/bench_rtfx_sharded.py
@@ -1,0 +1,67 @@
+import os
+os.environ["PATH"]="/usr/bin:/bin:/usr/sbin:/sbin:"+os.environ.get("PATH","")
+import argparse, glob, time
+from pathlib import Path
+import coremltools as ct, numpy as np, soundfile as sf
+from test_coreml_streaming import NemotronCoreMLStreaming, load_ground_truth, compute_wer
+
+class ShardedStreaming(NemotronCoreMLStreaming):
+    def load_all(self, model_dir, shard_dir, suffix):
+        md=Path(model_dir); sd=Path(shard_dir); cu=ct.ComputeUnit.CPU_AND_NE
+        self.preprocessor=ct.models.MLModel(str(md/"preprocessor.mlpackage"),compute_units=cu)
+        self.fused=ct.models.MLModel(str(md/"decoder_joint.mlpackage"),compute_units=cu)
+        self.head=ct.models.MLModel(str(sd/f"shard0_head{suffix}.mlpackage"),compute_units=cu)
+        self.bodies=[ct.models.MLModel(str(sd/f"shard{i}_{'tail' if i==3 else 'body'}{suffix}.mlpackage"),compute_units=cu) for i in (1,2,3)]
+    def encode(self, input_mel, cache_channel, cache_time, cache_len):
+        mlen=np.array([self.total_mel_frames],dtype=np.int32)
+        o=self.head.predict({"features":input_mel.astype(np.float32),"length":mlen,
+            "cache_ch":cache_channel[:,0:6],"cache_t":cache_time[:,0:6],"cache_len":cache_len})
+        h=o["hidden"];pos=o["pos_emb"];att=o["att_mask"];pad=o["pad_mask"]
+        ccp=[o["cache_ch_out"]];ctp=[o["cache_t_out"]];clo=o["cache_len_out"]
+        for bi in range(1,4):
+            s,e=bi*6,(bi+1)*6
+            ob=self.bodies[bi-1].predict({"hidden":h,"pos_emb":pos,"att_mask":att,"pad_mask":pad,
+                "cache_ch":cache_channel[:,s:e],"cache_t":cache_time[:,s:e]})
+            h=ob.get("encoded",ob.get("hidden_out")); ccp.append(ob["cache_ch_out"]); ctp.append(ob["cache_t_out"])
+        return h, np.concatenate(ccp,axis=1), np.concatenate(ctp,axis=1), clo
+    def transcribe_streaming(self, audio):
+        audio=audio.astype(np.float32); total=len(audio)
+        cc,ct,cl=self._get_initial_cache(); h,c=self._get_initial_decoder_state()
+        last=self.blank_idx; toks=[]; mel_cache=None; off=0
+        while off<total:
+            chunk=audio[off:min(off+self.chunk_samples,total)]
+            if len(chunk)<self.chunk_samples: chunk=np.pad(chunk,(0,self.chunk_samples-len(chunk)))
+            pre=self.preprocessor.predict({"audio":chunk.reshape(1,-1),"audio_length":np.array([len(chunk)],dtype=np.int32)})
+            cmel=pre["mel"]
+            imel=np.concatenate([mel_cache,cmel],axis=2) if mel_cache is not None else np.pad(cmel,((0,0),(0,0),(self.pre_encode_cache,0)),mode="constant")
+            cf=imel.shape[2]
+            if cf<self.total_mel_frames: imel=np.pad(imel,((0,0),(0,0),(0,self.total_mel_frames-cf)),mode="constant")
+            elif cf>self.total_mel_frames: imel=imel[:,:,:self.total_mel_frames]
+            mel_cache=cmel[:,:,-self.pre_encode_cache:] if cmel.shape[2]>=self.pre_encode_cache else cmel
+            encoded,cc,ct,cl=self.encode(imel,cc,ct,cl)
+            for t in range(encoded.shape[2]):
+                es=encoded[:,:,t:t+1].astype(np.float32)
+                for _ in range(10):
+                    out=self.fused.predict({"token":np.array([[last]],dtype=np.int32),"token_length":np.array([1],dtype=np.int32),"h_in":h,"c_in":c,"encoder":es})
+                    p=int(np.argmax(out["logits"][0,0,0,:]))
+                    if p==self.blank_idx: break
+                    toks.append(p); last=p; h,c=out["h_out"],out["c_out"]
+            off+=self.chunk_samples
+        return self._decode_tokens(toks)
+
+def main():
+    ap=argparse.ArgumentParser()
+    ap.add_argument("--model-dir",required=True); ap.add_argument("--shard-dir",required=True)
+    ap.add_argument("--suffix",default="_pal6"); ap.add_argument("--dataset",required=True)
+    ap.add_argument("--num-files",type=int,default=100); ap.add_argument("--warmup",type=int,default=3)
+    a=ap.parse_args()
+    inf=ShardedStreaming(a.model_dir); inf.load_all(a.model_dir,a.shard_dir,a.suffix)
+    gt=load_ground_truth(a.dataset); files=sorted(glob.glob(f"{a.dataset}/**/*.flac",recursive=True))[:a.num_files+a.warmup]
+    te=tw=0; aud=comp=0.0; n=0
+    for i,p in enumerate(files):
+        au,sr=sf.read(p,dtype="float32"); t0=time.perf_counter(); hyp=inf.transcribe_streaming(au); dt=time.perf_counter()-t0
+        if i<a.warmup: continue
+        n+=1; aud+=len(au)/sr; comp+=dt
+        if Path(p).stem in gt: e,w=compute_wer(gt[Path(p).stem],hyp); te+=e; tw+=w
+    print(f"SHARDED+B1  chunk={inf.chunk_mel_frames}  WER={100*te/max(tw,1):.2f}%  RTFx={aud/comp:.1f}")
+main()

--- a/models/stt/nemotron-speech-streaming-0.6b/coreml/conversion_scripts/convert_fe_conformer.py
+++ b/models/stt/nemotron-speech-streaming-0.6b/coreml/conversion_scripts/convert_fe_conformer.py
@@ -1,0 +1,28 @@
+import os
+os.environ["PATH"]="/usr/bin:/bin:/usr/sbin:/sbin:"+os.environ.get("PATH","")
+import sys; sys.path.insert(0,".")
+import torch, numpy as np, coremltools as ct
+import nemo.collections.asr as nemo_asr
+from shard_encoder import FrontEndShard, BodyShard
+OUT="/Users/hanweng/Documents/parakeet-tdt-opt/nemotron_en/fe_conformer_2240ms"
+os.makedirs(OUT,exist_ok=True)
+m=nemo_asr.models.EncDecRNNTBPEModel.from_pretrained("nvidia/nemotron-speech-streaming-en-0.6b",map_location="cpu").eval()
+enc=m.encoder; enc.setup_streaming_params()
+cc,ctt,cl=enc.get_initial_cache_state(batch_size=1,device="cpu"); cl=cl.to(torch.int32)
+cc_b,ct_b=cc.transpose(0,1),ctt.transpose(0,1)
+tmf=233; mel=torch.randn(1,128,tmf); mlen=torch.tensor([tmf],dtype=torch.int32)
+fe=FrontEndShard(enc).eval()
+with torch.no_grad(): a,pos,att,pad,clo=fe(mel,mlen,cl)
+conf=BodyShard(enc,0,24,is_tail=True).eval()
+with torch.no_grad(): enc_out,cco,cto=conf(a,pos,att,pad,cc_b,ct_b)
+def cv(mod,name,ex,nin,nout,unit):
+    tr=torch.jit.trace(mod.eval(),ex,strict=False)
+    inputs=[ct.TensorType(name=n,shape=tuple(e.shape),dtype=np.float32 if e.dtype==torch.float32 else np.int32) for n,e in zip(nin,ex)]
+    mm=ct.convert(tr,inputs=inputs,outputs=[ct.TensorType(name=n) for n in nout],
+        minimum_deployment_target=ct.target.iOS17,compute_precision=ct.precision.FLOAT16,compute_units=unit)
+    mm.save(f"{OUT}/{name}.mlpackage"); print("saved",name)
+cv(fe,"frontend",(mel,mlen,cl),["features","length","cache_len"],
+   ["hidden","pos_emb","att_mask","pad_mask","cache_len_out"], ct.ComputeUnit.CPU_ONLY)
+cv(conf,"conformer",(a,pos,att,pad,cc_b,ct_b),["hidden","pos_emb","att_mask","pad_mask","cache_ch","cache_t"],
+   ["encoded","cache_ch_out","cache_t_out"], ct.ComputeUnit.CPU_AND_NE)
+print("DONE")

--- a/models/stt/nemotron-speech-streaming-0.6b/coreml/conversion_scripts/convert_fused_decoder_joint.py
+++ b/models/stt/nemotron-speech-streaming-0.6b/coreml/conversion_scripts/convert_fused_decoder_joint.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""B1 fusion: export a single decoder+joint CoreML model for Nemotron streaming.
+
+Merges the RNNT prediction network (decoder LSTM) and the joint network into one
+mlpackage so the streaming decode loop makes ONE CoreML dispatch per step instead
+of two. Argmax stays in Swift (NOT fused in) — fusing argmax over the vocab forces
+ANE->CPU and regresses RTFx (the investigation's "B2" dead-end).
+
+  inputs : token[1,1] i32, token_length[1] i32, h_in[2,1,640], c_in[2,1,640],
+           encoder_step[1,1024,1]
+  outputs: logits[1,1,1,vocab], h_out[2,1,640], c_out[2,1,640]
+
+decoder/joint are chunk-independent, so one build serves every chunk tier.
+"""
+from __future__ import annotations
+import sys
+from pathlib import Path
+from typing import Tuple
+
+import coremltools as ct
+import numpy as np
+import torch
+import typer
+
+import nemo.collections.asr as nemo_asr
+from individual_components import DecoderWrapper, JointWrapper, ExportSettings, _coreml_convert
+
+DEFAULT_MODEL_ID = "nvidia/nemotron-speech-streaming-en-0.6b"
+
+
+class DecoderJointFusedWrapper(torch.nn.Module):
+    def __init__(self, decoder: DecoderWrapper, joint: JointWrapper) -> None:
+        super().__init__()
+        self.decoder = decoder
+        self.joint = joint
+
+    def forward(self, token, token_length, h_in, c_in, encoder_step):
+        dec_out, h_out, c_out = self.decoder(token, token_length, h_in, c_in)  # [1,640,1]
+        logits = self.joint(encoder_step, dec_out)  # [1,1,1,vocab]
+        return logits, h_out, c_out
+
+
+app = typer.Typer(add_completion=False)
+
+
+@app.command()
+def convert(
+    output: Path = typer.Option(..., help="Output .mlpackage path"),
+    precision: str = typer.Option("FLOAT16", help="FLOAT16 or FLOAT32"),
+) -> None:
+    typer.echo("Loading model...")
+    model = nemo_asr.models.EncDecRNNTBPEModel.from_pretrained(DEFAULT_MODEL_ID, map_location="cpu")
+    model.eval()
+    model.decoder._rnnt_export = True
+
+    decoder = DecoderWrapper(model.decoder.eval())
+    joint = JointWrapper(model.joint.eval())
+    fused = DecoderJointFusedWrapper(decoder, joint).eval()
+
+    dh = int(model.decoder.pred_hidden)
+    dl = int(model.decoder.pred_rnn_layers)
+    enc_dim = int(model.joint.enc.in_features) if hasattr(model.joint, "enc") else 1024
+
+    token = torch.tensor([[model.decoder.blank_idx]], dtype=torch.int32)
+    token_len = torch.tensor([1], dtype=torch.int32)
+    h = torch.zeros(dl, 1, dh)
+    c = torch.zeros(dl, 1, dh)
+    enc_step = torch.randn(1, enc_dim, 1)
+
+    settings = ExportSettings(
+        output_dir=output.parent,
+        compute_units=ct.ComputeUnit.CPU_AND_NE,
+        deployment_target=ct.target.iOS17,
+        compute_precision=ct.precision.FLOAT16 if precision.upper() == "FLOAT16" else ct.precision.FLOAT32,
+        max_audio_seconds=30.0,
+        max_symbol_steps=1,
+        chunk_size_frames=14,
+        cache_size=70,
+    )
+
+    traced = torch.jit.trace(fused, (token, token_len, h, c, enc_step), strict=False)
+    inputs = [
+        ct.TensorType(name="token", shape=(1, 1), dtype=np.int32),
+        ct.TensorType(name="token_length", shape=(1,), dtype=np.int32),
+        ct.TensorType(name="h_in", shape=tuple(h.shape), dtype=np.float32),
+        ct.TensorType(name="c_in", shape=tuple(c.shape), dtype=np.float32),
+        ct.TensorType(name="encoder", shape=tuple(enc_step.shape), dtype=np.float32),
+    ]
+    outputs = [
+        ct.TensorType(name="logits", dtype=np.float32),
+        ct.TensorType(name="h_out", dtype=np.float32),
+        ct.TensorType(name="c_out", dtype=np.float32),
+    ]
+    mlmodel = _coreml_convert(traced, inputs, outputs, settings, ct.ComputeUnit.CPU_AND_NE)
+    mlmodel.save(str(output))
+    typer.echo(f"Done! Fused decoder+joint -> {output}")
+
+
+if __name__ == "__main__":
+    app()

--- a/models/stt/nemotron-speech-streaming-0.6b/coreml/conversion_scripts/convert_nemotron_streaming.py
+++ b/models/stt/nemotron-speech-streaming-0.6b/coreml/conversion_scripts/convert_nemotron_streaming.py
@@ -60,9 +60,29 @@ def convert(
     output_dir: Path = typer.Option(Path("nemotron_coreml"), help="Output directory"),
     encoder_cu: str = typer.Option("CPU_AND_NE", help="Encoder compute units"),
     precision: str = typer.Option("FLOAT32", help="FLOAT32 or FLOAT16"),
+    chunk_mel_frames: int = typer.Option(
+        CHUNK_MEL_FRAMES,
+        help="Mel frames per streaming chunk. 112=1120ms (default/shipped), 224=2240ms tier. "
+        "Must be a clean multiple of the trained 112 (=14 encoder frames) to keep the "
+        "chunked-attention mask aligned.",
+    ),
 ) -> None:
     """Export Nemotron Streaming to CoreML."""
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Derive chunk geometry from the requested mel-chunk size.
+    if chunk_mel_frames % 112 != 0:
+        typer.echo(
+            f"WARNING: chunk_mel_frames={chunk_mel_frames} is not a multiple of 112 "
+            "(the trained 14-encoder-frame chunk); the attention mask may misalign."
+        )
+    chunk_mel = chunk_mel_frames
+    total_mel = chunk_mel + PRE_ENCODE_CACHE
+    chunk_enc_frames = chunk_mel // 8  # subsampling factor 8
+    typer.echo(
+        f"Chunk geometry: chunk_mel={chunk_mel} (~{chunk_mel * 10}ms), "
+        f"total_mel={total_mel}, chunk_enc_frames={chunk_enc_frames}"
+    )
 
     typer.echo("Loading model...")
     model = nemo_asr.models.EncDecRNNTBPEModel.from_pretrained(DEFAULT_MODEL_ID, map_location="cpu")
@@ -97,7 +117,7 @@ def convert(
         compute_precision=ct.precision.FLOAT16 if precision.upper() == "FLOAT16" else ct.precision.FLOAT32,
         max_audio_seconds=30.0,
         max_symbol_steps=1,
-        chunk_size_frames=14,
+        chunk_size_frames=chunk_enc_frames,
         cache_size=cache_channel.shape[2],
     )
 
@@ -122,8 +142,8 @@ def convert(
     # === Encoder (streaming) ===
     typer.echo("Exporting encoder...")
     mel_features = int(model.cfg.preprocessor.features)  # 128 for this model
-    mel = torch.randn(1, mel_features, TOTAL_MEL_FRAMES)
-    mel_len = torch.tensor([TOTAL_MEL_FRAMES], dtype=torch.int32)
+    mel = torch.randn(1, mel_features, total_mel)
+    mel_len = torch.tensor([total_mel], dtype=torch.int32)
 
     traced = torch.jit.trace(
         encoder_streaming,
@@ -205,9 +225,9 @@ def convert(
         "model": DEFAULT_MODEL_ID,
         "sample_rate": sample_rate,
         "mel_features": mel_features,
-        "chunk_mel_frames": CHUNK_MEL_FRAMES,
+        "chunk_mel_frames": chunk_mel,
         "pre_encode_cache": PRE_ENCODE_CACHE,
-        "total_mel_frames": TOTAL_MEL_FRAMES,
+        "total_mel_frames": total_mel,
         "vocab_size": vocab_size,
         "blank_idx": int(model.decoder.blank_idx),
         "cache_channel_shape": list(cache_channel_b.shape),

--- a/models/stt/nemotron-speech-streaming-0.6b/coreml/conversion_scripts/convert_shards.py
+++ b/models/stt/nemotron-speech-streaming-0.6b/coreml/conversion_scripts/convert_shards.py
@@ -1,0 +1,44 @@
+import os
+os.environ["PATH"]="/usr/bin:/bin:/usr/sbin:/sbin:"+os.environ.get("PATH","")
+import sys; sys.path.insert(0,".")
+import torch, numpy as np, coremltools as ct
+import nemo.collections.asr as nemo_asr
+from shard_encoder import HeadShard, BodyShard
+OUT="/Users/hanweng/Documents/parakeet-tdt-opt/nemotron_en/shards_2240ms"
+os.makedirs(OUT, exist_ok=True)
+m=nemo_asr.models.EncDecRNNTBPEModel.from_pretrained("nvidia/nemotron-speech-streaming-en-0.6b",map_location="cpu").eval()
+enc=m.encoder; enc.setup_streaming_params()
+cc,ctt,cl=enc.get_initial_cache_state(batch_size=1,device="cpu"); cl=cl.to(torch.int32)
+cc_b,ct_b=cc.transpose(0,1),ctt.transpose(0,1)
+tmf=233; mel=torch.randn(1,128,tmf); mlen=torch.tensor([tmf],dtype=torch.int32)
+splits=[0,6,12,18,24]
+def conv(mod, name, example, names_in, names_out):
+    mod=mod.eval()
+    tr=torch.jit.trace(mod, example, strict=False)
+    inputs=[ct.TensorType(name=n, shape=tuple(e.shape), dtype=np.float32 if e.dtype==torch.float32 else np.int32) for n,e in zip(names_in,example)]
+    outs=[ct.TensorType(name=n) for n in names_out]
+    mm=ct.convert(tr, inputs=inputs, outputs=outs, minimum_deployment_target=ct.target.iOS17, compute_precision=ct.precision.FLOAT16, compute_units=ct.ComputeUnit.CPU_AND_NE)
+    p=f"{OUT}/{name}.mlpackage"; mm.save(p); print("saved",name)
+    return mm
+# head
+head=HeadShard(enc,6)
+hex=(mel,mlen,cc_b[:,0:6],ct_b[:,0:6],cl)
+with torch.no_grad(): hout=head(*hex)
+a,pos,att,pad,h_cc,h_ct,clo=hout
+conv(head,"shard0_head",hex,
+     ["features","length","cache_ch","cache_t","cache_len"],
+     ["hidden","pos_emb","att_mask","pad_mask","cache_ch_out","cache_t_out","cache_len_out"])
+print("intermediates: hidden",tuple(a.shape),"pos",tuple(pos.shape),"att",tuple(att.shape),"pad",tuple(pad.shape))
+# bodies
+cur=a
+for bi in range(1,4):
+    s,e=splits[bi],splits[bi+1]
+    body=BodyShard(enc,s,e,is_tail=(bi==3))
+    bex=(cur,pos,att,pad,cc_b[:,s:e],ct_b[:,s:e])
+    with torch.no_grad(): bo=body(*bex)
+    cur=bo[0]
+    nm="shard%d_%s"%(bi,"tail" if bi==3 else "body")
+    conv(body,nm,bex,
+         ["hidden","pos_emb","att_mask","pad_mask","cache_ch","cache_t"],
+         ["encoded" if bi==3 else "hidden_out","cache_ch_out","cache_t_out"])
+print("DONE all shards")

--- a/models/stt/nemotron-speech-streaming-0.6b/coreml/conversion_scripts/shard_encoder.py
+++ b/models/stt/nemotron-speech-streaming-0.6b/coreml/conversion_scripts/shard_encoder.py
@@ -147,3 +147,35 @@ def parity_check():
 
 if __name__ == "__main__":
     parity_check()
+
+
+class FrontEndShard(torch.nn.Module):
+    """Preamble only: pre_encode + pos_enc + masks. No conformer layers.
+    Outputs the intermediates the conformer shard needs, plus cache_len_out."""
+    def __init__(self, enc):
+        super().__init__()
+        self.enc = enc
+
+    def forward(self, features, length, cache_len_in):
+        enc = self.enc
+        clcl = cache_len_in.to(torch.int64)
+        audio_signal = torch.transpose(features, 1, 2)
+        audio_signal, length = enc.pre_encode(x=audio_signal, lengths=length.to(torch.int64))
+        if enc.streaming_cfg.drop_extra_pre_encoded > 0:
+            audio_signal = audio_signal[:, enc.streaming_cfg.drop_extra_pre_encoded:, :]
+            length = (length - enc.streaming_cfg.drop_extra_pre_encoded).clamp(min=0)
+        max_audio_length = audio_signal.size(1)
+        cache_len = enc.streaming_cfg.last_channel_cache_size
+        cache_keep_size = max_audio_length - enc.streaming_cfg.cache_drop_size
+        max_audio_length = max_audio_length + cache_len
+        padding_length = length + cache_len
+        offset = torch.neg(clcl) + cache_len
+        audio_signal, pos_emb = enc.pos_enc(x=audio_signal, cache_len=cache_len)
+        pad_mask, att_mask = enc._create_masks(
+            att_context_size=enc.att_context_size, padding_length=padding_length,
+            max_audio_length=max_audio_length, offset=offset, device=audio_signal.device)
+        pad_mask = pad_mask[:, cache_len:]
+        if att_mask is not None:
+            att_mask = att_mask[:, cache_len:]
+        cache_len_out = torch.clamp(clcl + cache_keep_size, max=cache_len).to(torch.int32)
+        return audio_signal, pos_emb, att_mask, pad_mask, cache_len_out

--- a/models/stt/nemotron-speech-streaming-0.6b/coreml/conversion_scripts/shard_encoder.py
+++ b/models/stt/nemotron-speech-streaming-0.6b/coreml/conversion_scripts/shard_encoder.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Shard the Nemotron streaming encoder into N CoreML models for ANE.
+
+The 24-layer FastConformer encoder is too big for the iOS ANE working set
+(1.4GB / 130s load as a single model). Splitting the layer stack into N shards
+lets each shard fit + load fast while keeping ANE-speed inference. The shared
+tensors (pos_emb, att_mask, pad_mask) computed in the preamble are passed
+between shards; per-layer caches are sliced by layer index.
+
+  Head shard : mel + cache[0:k] -> hidden, pos_emb, att_mask, pad_mask, cache_out[0:k]
+  Body/Tail  : hidden + pos_emb + att_mask + pad_mask + cache[a:b]
+               -> hidden(+out_proj on tail) + cache_out[a:b]
+"""
+from __future__ import annotations
+import torch
+
+
+class HeadShard(torch.nn.Module):
+    """Preamble (pre_encode, pos_enc, masks) + layers[0:n_layers]."""
+
+    def __init__(self, enc, n_layers):
+        super().__init__()
+        self.enc = enc
+        self.n = n_layers
+
+    def forward(self, features, length, cache_ch, cache_t, cache_len_in):
+        enc = self.enc
+        # cache passed as [B, n, ...] -> [n, B, ...]
+        cache_ch = cache_ch.transpose(0, 1)
+        cache_t = cache_t.transpose(0, 1)
+        clcl = cache_len_in.to(torch.int64)
+
+        audio_signal = torch.transpose(features, 1, 2)
+        audio_signal, length = enc.pre_encode(x=audio_signal, lengths=length.to(torch.int64))
+        if enc.streaming_cfg.drop_extra_pre_encoded > 0:
+            audio_signal = audio_signal[:, enc.streaming_cfg.drop_extra_pre_encoded:, :]
+            length = (length - enc.streaming_cfg.drop_extra_pre_encoded).clamp(min=0)
+
+        max_audio_length = audio_signal.size(1)
+        cache_len = enc.streaming_cfg.last_channel_cache_size
+        cache_keep_size = max_audio_length - enc.streaming_cfg.cache_drop_size
+        max_audio_length = max_audio_length + cache_len
+        padding_length = length + cache_len
+        offset = torch.neg(clcl) + cache_len
+
+        audio_signal, pos_emb = enc.pos_enc(x=audio_signal, cache_len=cache_len)
+        pad_mask, att_mask = enc._create_masks(
+            att_context_size=enc.att_context_size, padding_length=padding_length,
+            max_audio_length=max_audio_length, offset=offset, device=audio_signal.device)
+        pad_mask = pad_mask[:, cache_len:]
+        if att_mask is not None:
+            att_mask = att_mask[:, cache_len:]
+
+        ch_next, t_next = [], []
+        for lth in range(self.n):
+            out = enc.layers[lth](
+                x=audio_signal, att_mask=att_mask, pos_emb=pos_emb, pad_mask=pad_mask,
+                cache_last_channel=cache_ch[lth], cache_last_time=cache_t[lth])
+            audio_signal, cc, ct = out
+            ch_next.append(cc); t_next.append(ct)
+        cache_len_out = torch.clamp(clcl + cache_keep_size, max=cache_len).to(torch.int32)
+        # masks/pos_emb passed to next shard; stack our cache slice back to [B, n, ...]
+        return (audio_signal, pos_emb, att_mask, pad_mask,
+                torch.stack(ch_next, 0).transpose(0, 1), torch.stack(t_next, 0).transpose(0, 1),
+                cache_len_out)
+
+
+class BodyShard(torch.nn.Module):
+    """layers[start:end]; optional out_proj + final transpose on the tail."""
+
+    def __init__(self, enc, start, end, is_tail):
+        super().__init__()
+        self.enc = enc
+        self.start, self.end = start, end
+        self.is_tail = is_tail
+
+    def forward(self, audio_signal, pos_emb, att_mask, pad_mask, cache_ch, cache_t):
+        enc = self.enc
+        cache_ch = cache_ch.transpose(0, 1)
+        cache_t = cache_t.transpose(0, 1)
+        ch_next, t_next = [], []
+        for i, lth in enumerate(range(self.start, self.end)):
+            out = enc.layers[lth](
+                x=audio_signal, att_mask=att_mask, pos_emb=pos_emb, pad_mask=pad_mask,
+                cache_last_channel=cache_ch[i], cache_last_time=cache_t[i])
+            audio_signal, cc, ct = out
+            ch_next.append(cc); t_next.append(ct)
+        ch_out = torch.stack(ch_next, 0).transpose(0, 1)
+        t_out = torch.stack(t_next, 0).transpose(0, 1)
+        if self.is_tail:
+            if enc.out_proj is not None:
+                audio_signal = enc.out_proj(audio_signal)
+            encoded = torch.transpose(audio_signal, 1, 2)
+            return encoded, ch_out, t_out
+        return audio_signal, ch_out, t_out
+
+
+def parity_check():
+    """Compose head+body shards and compare against the full encoder forward."""
+    import sys
+    sys.path.insert(0, ".")
+    import nemo.collections.asr as nemo_asr
+    from individual_components import EncoderStreamingWrapper
+    m = nemo_asr.models.EncDecRNNTBPEModel.from_pretrained(
+        "nvidia/nemotron-speech-streaming-en-0.6b", map_location="cpu").eval()
+    enc = m.encoder
+    enc.setup_streaming_params()
+    L = len(enc.layers)
+    print(f"layers={L}, out_proj={enc.out_proj is not None}, reduction_position={enc.reduction_position}")
+
+    cc, ct, cl = enc.get_initial_cache_state(batch_size=1, device="cpu")
+    cl = cl.to(torch.int32)
+    cc_b, ct_b = cc.transpose(0, 1), ct.transpose(0, 1)  # [B, L, ...]
+    n_mel = int(m.cfg.preprocessor.features)
+    tmf = 233
+    mel = torch.randn(1, n_mel, tmf)
+    mlen = torch.tensor([tmf], dtype=torch.int32)
+
+    # reference: full streaming wrapper
+    ref = EncoderStreamingWrapper(enc.eval())
+    with torch.no_grad():
+        r_enc, r_len, r_cc, r_ct, r_cl = ref(mel, mlen, cc_b, ct_b, cl)
+
+    # sharded composition: 4 shards of 6
+    splits = [0, 6, 12, 18, 24]
+    head = HeadShard(enc, splits[1]).eval()
+    bodies = [BodyShard(enc, splits[i], splits[i+1], is_tail=(i == 3)).eval() for i in range(1, 4)]
+    with torch.no_grad():
+        a, pos, att, pad, h_cc, h_ct, cl_out = head(
+            mel, mlen, cc_b[:, 0:6], ct_b[:, 0:6], cl)
+        cc_parts, ct_parts = [h_cc], [h_ct]
+        for bi, b in enumerate(bodies):
+            s, e = splits[bi+1], splits[bi+2]
+            a, b_cc, b_ct = b(a, pos, att, pad, cc_b[:, s:e], ct_b[:, s:e])
+            cc_parts.append(b_cc); ct_parts.append(b_ct)
+        s_enc = a
+        s_cc = torch.cat(cc_parts, dim=1)
+        s_ct = torch.cat(ct_parts, dim=1)
+
+    d = lambda x, y: (x - y).abs().max().item()
+    # EncoderStreamingWrapper already returns caches as [B, L, ...]; compare directly.
+    print(f"encoded   max|Δ| = {d(r_enc, s_enc):.6e}")
+    print(f"cache_ch  max|Δ| = {d(r_cc, s_cc):.6e}")
+    print(f"cache_t   max|Δ| = {d(r_ct, s_ct):.6e}")
+    print(f"cache_len ref={r_cl.flatten().tolist()} shard={cl_out.flatten().tolist()}")
+
+
+if __name__ == "__main__":
+    parity_check()

--- a/models/stt/nemotron-speech-streaming-0.6b/coreml/encoder_perf.py
+++ b/models/stt/nemotron-speech-streaming-0.6b/coreml/encoder_perf.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Isolated load-time / inference-latency / peak-memory probe for one encoder config.
+
+Run as a subprocess (fresh process => clean peak-RSS) per config:
+  encoder_perf.py <encoder.mlpackage|.mlmodelc> <CPU_ONLY|CPU_AND_NE|CPU_AND_GPU> <metadata.json>
+Prints one line: load_s, infer_ms_median, peak_rss_mb.
+"""
+import os
+os.environ["PATH"] = "/usr/bin:/bin:/usr/sbin:/sbin:" + os.environ.get("PATH", "")
+import sys, json, time, resource
+import numpy as np
+import coremltools as ct
+
+path, unit_name, meta_path = sys.argv[1], sys.argv[2], sys.argv[3]
+unit = {"CPU_ONLY": ct.ComputeUnit.CPU_ONLY, "CPU_AND_NE": ct.ComputeUnit.CPU_AND_NE,
+        "CPU_AND_GPU": ct.ComputeUnit.CPU_AND_GPU}[unit_name]
+md = json.load(open(meta_path))
+tmf = md["total_mel_frames"]; cc = md["cache_channel_shape"]; ctt = md["cache_time_shape"]
+feed = {"mel": np.random.randn(1, 128, tmf).astype(np.float32),
+        "mel_length": np.array([tmf], dtype=np.int32),
+        "cache_channel": np.random.randn(*cc).astype(np.float32),
+        "cache_time": np.random.randn(*ctt).astype(np.float32),
+        "cache_len": np.array([0], dtype=np.int32)}
+
+t0 = time.perf_counter()
+if path.endswith(".mlmodelc"):
+    m = ct.models.CompiledMLModel(path, unit)
+else:
+    m = ct.models.MLModel(path, compute_units=unit)
+load_s = time.perf_counter() - t0
+
+for _ in range(3):
+    m.predict(feed)
+t = []
+for _ in range(25):
+    s = time.perf_counter(); m.predict(feed); t.append((time.perf_counter() - s) * 1000)
+t = sorted(t)
+peak_mb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / (1024 * 1024)  # macOS: bytes
+line = f"{sys.argv[5] if len(sys.argv) > 5 else path} {unit_name} load={load_s:.2f}s infer={t[len(t)//2]:.2f}ms mem={peak_mb:.0f}MB"
+print(f"RESULT {line}")
+if len(sys.argv) > 4 and sys.argv[4]:
+    with open(sys.argv[4], "a") as f:
+        f.write(line + "\n")

--- a/models/stt/nemotron-speech-streaming-0.6b/coreml/int8_quantize_encoder.py
+++ b/models/stt/nemotron-speech-streaming-0.6b/coreml/int8_quantize_encoder.py
@@ -1,0 +1,12 @@
+import sys, coremltools as ct
+from coremltools.optimize.coreml import (
+    OpLinearQuantizerConfig, OptimizationConfig, linear_quantize_weights)
+src, dst = sys.argv[1], sys.argv[2]
+m = ct.models.MLModel(src, compute_units=ct.ComputeUnit.CPU_AND_NE)
+try: m.minimum_deployment_target = ct.target.iOS17
+except Exception: pass
+cfg = OptimizationConfig(global_config=OpLinearQuantizerConfig(
+    mode="linear_symmetric", granularity="per_channel", dtype="int8"))
+q = linear_quantize_weights(m, cfg)
+q.save(dst)
+print("saved", dst)

--- a/models/stt/nemotron-speech-streaming-0.6b/coreml/quant_variants.py
+++ b/models/stt/nemotron-speech-streaming-0.6b/coreml/quant_variants.py
@@ -1,0 +1,17 @@
+import sys, coremltools as ct
+from coremltools.optimize.coreml import (OpLinearQuantizerConfig, OpPalettizerConfig,
+    OptimizationConfig, linear_quantize_weights, palettize_weights)
+src, dst, kind = sys.argv[1], sys.argv[2], sys.argv[3]
+m = ct.models.MLModel(src, compute_units=ct.ComputeUnit.CPU_AND_NE)
+try: m.minimum_deployment_target = ct.target.iOS17
+except Exception: pass
+if kind == "int4":
+    cfg = OptimizationConfig(global_config=OpLinearQuantizerConfig(mode="linear_symmetric", granularity="per_channel", dtype="int4"))
+    q = linear_quantize_weights(m, cfg)
+elif kind == "pal6":
+    cfg = OptimizationConfig(global_config=OpPalettizerConfig(mode="kmeans", nbits=6))
+    q = palettize_weights(m, cfg)
+elif kind == "pal4":
+    cfg = OptimizationConfig(global_config=OpPalettizerConfig(mode="kmeans", nbits=4))
+    q = palettize_weights(m, cfg)
+q.save(dst); print("saved", dst)

--- a/models/stt/nemotron-speech-streaming-0.6b/coreml/shard_perf.py
+++ b/models/stt/nemotron-speech-streaming-0.6b/coreml/shard_perf.py
@@ -1,0 +1,49 @@
+import os
+os.environ["PATH"]="/usr/bin:/bin:/usr/sbin:/sbin:"+os.environ.get("PATH","")
+import time, json, resource, numpy as np, coremltools as ct
+SH="/Users/hanweng/Documents/parakeet-tdt-opt/nemotron_en/shards_2240ms"
+SINGLE="/Users/hanweng/Documents/parakeet-tdt-opt/nemotron_en/coreml_2240ms/encoder.mlpackage"
+md=json.load(open("/Users/hanweng/Documents/parakeet-tdt-opt/nemotron_en/coreml_2240ms/metadata.json"))
+tmf=md["total_mel_frames"]; cc=md["cache_channel_shape"]; ctt=md["cache_time_shape"]  # [1,24,70,1024],[1,24,1024,8]
+U=ct.ComputeUnit.CPU_AND_NE
+mel=np.random.randn(1,128,tmf).astype(np.float32); mlen=np.array([tmf],dtype=np.int32)
+cache_ch=np.random.randn(*cc).astype(np.float32); cache_t=np.random.randn(*ctt).astype(np.float32); clen=np.array([0],dtype=np.int32)
+
+# --- single encoder ---
+t0=time.perf_counter(); single=ct.models.MLModel(SINGLE,compute_units=U); single_load=time.perf_counter()-t0
+sfeed={"mel":mel,"mel_length":mlen,"cache_channel":cache_ch,"cache_time":cache_t,"cache_len":clen}
+for _ in range(3): single.predict(sfeed)
+t=[time.perf_counter() for _ in [0]]; 
+import statistics
+ts=[]
+for _ in range(15):
+    s=time.perf_counter(); so=single.predict(sfeed); ts.append((time.perf_counter()-s)*1000)
+single_inf=sorted(ts)[len(ts)//2]
+enc_single=np.array(so["encoded"])
+
+# --- shards ---
+names=["shard0_head","shard1_body","shard2_body","shard3_tail"]
+loads=[]; shards=[]
+for n in names:
+    t0=time.perf_counter(); mm=ct.models.MLModel(f"{SH}/{n}.mlpackage",compute_units=U); loads.append(time.perf_counter()-t0); shards.append(mm)
+def run_shards():
+    o=shards[0].predict({"features":mel,"length":mlen,"cache_ch":cache_ch[:,0:6],"cache_t":cache_t[:,0:6],"cache_len":clen})
+    h=o["hidden"]; pos=o["pos_emb"]; att=o["att_mask"]; pad=o["pad_mask"]
+    for bi in range(1,4):
+        s,e=bi*6,(bi+1)*6
+        fd={"hidden":h,"pos_emb":pos,"att_mask":att,"pad_mask":pad,"cache_ch":cache_ch[:,s:e],"cache_t":cache_t[:,s:e]}
+        o=shards[bi].predict(fd)
+        h=o.get("encoded", o.get("hidden_out"))
+    return h
+for _ in range(3): run_shards()
+ts=[]
+for _ in range(15):
+    s=time.perf_counter(); enc_shard=run_shards(); ts.append((time.perf_counter()-s)*1000)
+shard_inf=sorted(ts)[len(ts)//2]
+enc_shard=np.array(enc_shard)
+peak=resource.getrusage(resource.RUSAGE_SELF).ru_maxrss/(1024*1024)
+
+print(f"SINGLE  load={single_load:.2f}s  infer={single_inf:.2f}ms")
+print(f"SHARDS  load_total={sum(loads):.2f}s  per_shard={[round(x,2) for x in loads]}  infer_total={shard_inf:.2f}ms")
+print(f"PARITY  encoded max|Δ|={np.abs(enc_single-enc_shard).max():.6e}  shape {enc_single.shape}")
+print(f"peak_rss (both loaded) = {peak:.0f}MB")

--- a/models/stt/nemotron-speech-streaming-0.6b/coreml/stage_hf_tier.py
+++ b/models/stt/nemotron-speech-streaming-0.6b/coreml/stage_hf_tier.py
@@ -1,0 +1,26 @@
+import sys, json, shutil
+from pathlib import Path
+import coremltools as ct
+src = Path(sys.argv[1])   # coreml_2240ms dir (has *.mlpackage, encoder_int8.mlpackage, metadata, tokenizer)
+dst = Path(sys.argv[2])   # output nemotron_coreml_2240ms dir
+dst.mkdir(parents=True, exist_ok=True)
+(dst / "encoder").mkdir(exist_ok=True)
+
+def compile_to(pkg, out_mlmodelc):
+    m = ct.models.MLModel(str(pkg), compute_units=ct.ComputeUnit.CPU_AND_NE)
+    cpath = m.get_compiled_model_path()
+    if out_mlmodelc.exists(): shutil.rmtree(out_mlmodelc)
+    shutil.copytree(cpath, out_mlmodelc)
+    print("compiled", out_mlmodelc.name)
+
+compile_to(src / "preprocessor.mlpackage", dst / "preprocessor.mlmodelc")
+compile_to(src / "decoder.mlpackage",      dst / "decoder.mlmodelc")
+compile_to(src / "joint.mlpackage",        dst / "joint.mlmodelc")
+compile_to(src / "encoder_int8.mlpackage", dst / "encoder" / "encoder_int8.mlmodelc")
+
+# metadata + chunk_ms
+md = json.loads((src / "metadata.json").read_text())
+md["chunk_ms"] = md["chunk_mel_frames"] * 10
+(dst / "metadata.json").write_text(json.dumps(md, indent=2))
+shutil.copy(src / "tokenizer.json", dst / "tokenizer.json")
+print("staged ->", dst)


### PR DESCRIPTION
## Summary

Conversion tooling + empirical optimization sweep for the English Nemotron streaming model, validated faithful to the public `nvidia/nemotron-speech-streaming-en-0.6b` checkpoint (decoder & joint CoreML match PyTorch at cos=1.000000). Companion to FluidInference/FluidAudio#660.

2240ms tier weights uploaded to [`nemotron-speech-streaming-en-0.6b-coreml/nemotron_coreml_2240ms/`](https://huggingface.co/FluidInference/nemotron-speech-streaming-en-0.6b-coreml/tree/main/nemotron_coreml_2240ms).

## Conversion tooling

- **`convert_nemotron_streaming.py`**: `--chunk-mel-frames` (112=1120ms default, 224=2240ms; derives chunk geometry, warns on non-multiple-of-112 tiling).
- **`convert_fused_decoder_joint.py`**: B1 fusion — single decoder+joint mlpackage (`token`/`token_length`/`h_in`/`c_in`/`encoder` → `logits`/`h_out`/`c_out`; argmax stays in Swift). Chunk-independent.
- **`quant_variants.py`** / **`int8_quantize_encoder.py`**: int8 / int4 / 6-bit-palette / 4-bit-palette encoder weight variants.
- **`shard_encoder.py`** / **`convert_shards.py`** / **`convert_fe_conformer.py`**: split the 24-layer FastConformer into N CoreML shards (parity bit-exact) and a front-end(CPU)/conformer(ANE) split.
- **`stage_hf_tier.py`**: compile mlpackage → mlmodelc + stage the HF tier folder.
- **`bench_rtfx*.py`** / **`encoder_perf.py`** / **`shard_perf.py`**: WER + RTFx + load/memory harnesses (separate, fused, and sharded paths; `--encoder-cu`).

## Key findings (2240ms, test-clean-100, M-series)

**Throughput levers (stackable, WER-neutral):** 2240ms chunk +41%; pal6 over int8 (2.24% vs 2.41% WER, +9% RTFx, smaller — strictly dominates); B1 fusion +15%. Fastest stack: **2240ms + pal6 + B1 = 104.3 RTFx / 2.24% WER** (single encoder on ANE).

**Encoder placement (the ANE-residency question):**

| Encoder | RTFx | Load | Notes |
|---------|------|------|-------|
| single pal6 @ ANE | 104.3 | 10.6s macOS / 130s+1.4GB iOS | fastest where it loads |
| single pal6 @ CPU | 65.6 | 0.07s / ~140MB | **iOS pick** |
| 4-way shard @ ANE | 33.5 | ~12s | dominated |

- **fp16-CPU encoder beats 4-way sharding ~2× on iOS** (65.6 vs 33.5) and loads instantly with low memory — so single-encoder-on-CPU is the iOS fix, not sharding.
- pre_encode is **not** the ANE load bottleneck (FE-on-CPU leaves conformer ANE load at 10.6s ≈ single); the head shard's slow load was the ~5s first-ANE-model init. FE/conformer split is RTFx-neutral but doesn't fix iOS residency (conformer stays monolithic). Layer-sharding is the only iOS-fit but inherently pays the 3× macOS inference penalty.
- fp32 (released compute precision) is uniformly 2-4× slower; ANE rejects fp32 → CPU.

## Note

The released English CoreML was built from a different source checkpoint than the public HF default (released decoder cos=0.71 vs public PyTorch), so reproducing its exact ~1.99% WER needs that checkpoint; these scripts are correct for the public model and ready to run on the production weights.

