### PR TITLE
feat(stt/nemotron-multilingual): OpenVINO IR export + INT8 + FLEURS benchmark

### DIFF
--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/.gitignore
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/.gitignore
@@ -1,0 +1,14 @@
+# Exported OpenVINO IR (large binaries — regenerate via export_openvino.py,
+# or download from HuggingFace FluidInference)
+build_ov/
+build_ov_fp16/
+build_ov_int8/
+*.xml
+*.bin
+
+# Scratch IR + source checkpoint
+scratch_*
+*.nemo
+
+# Benchmark run logs (noisy HF progress bars + stack traces); JSON results kept
+*.log

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/README.md
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/README.md
@@ -1,0 +1,126 @@
+---
+license: openmdw-1.1
+library_name: openvino
+pipeline_tag: automatic-speech-recognition
+base_model: nvidia/nemotron-3.5-asr-streaming-0.6b
+base_model_relation: quantized
+tags:
+  - openvino
+  - automatic-speech-recognition
+  - streaming-asr
+  - rnnt
+  - fastconformer
+  - cache-aware-streaming
+  - multilingual
+  - on-device
+  - intel
+language:
+  - en
+  - es
+  - fr
+  - de
+  - it
+  - pt
+  - nl
+  - pl
+  - ru
+  - uk
+  - zh
+  - ja
+  - ko
+  - ar
+  - hi
+---
+
+# Nemotron-3.5-ASR-Streaming-Multilingual 0.6B — OpenVINO IR
+
+OpenVINO IR export of NVIDIA's [`nvidia/nemotron-3.5-asr-streaming-0.6b`](https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b),
+a **cache-aware streaming FastConformer-RNNT** with prompt-conditioned multilingual decoding (40+ languages).
+This is the OpenVINO sibling of [`FluidInference/Nemotron-3.5-ASR-Streaming-Multilingual-0.6b-CoreML`](https://huggingface.co/FluidInference/Nemotron-3.5-ASR-Streaming-Multilingual-0.6b-CoreML),
+intended for the [eddy-audio](https://github.com/FluidInference/eddy-audio) runtime (OpenVINO, CPU / Intel NPU / iGPU).
+
+## Contents
+
+```
+fp32/   FP32 IR        (~2.5 GB)  — graph the WER/CER table below was measured on
+fp16/   FP16 IR        (~1.3 GB)  — identical transcripts, half the size, NPU-friendly
+int8/   INT8-weight IR (~749 MB)  — weight-only encoder (per-channel sym); WER matches FP32
+```
+
+Each folder holds 4 IR pairs plus the tokenizer + metadata:
+
+| file | role |
+|---|---|
+| `nemotron_preprocessor.xml/.bin` | 128-bin log-mel front end (16 kHz) |
+| `nemotron_encoder.xml/.bin` | 24-layer cache-aware streaming FastConformer (d_model=1024) + language `prompt_kernel` |
+| `nemotron_decoder.xml/.bin` | RNNT prediction network (2× LSTM @ 640) |
+| `nemotron_joint.xml/.bin` | joint network → vocab 13088 (blank=13087) |
+| `nemotron_vocab.json` | SentencePiece pieces (▁ word-boundary marker) |
+| `metadata.json` | shapes, cache dims, `prompt_dictionary` (lang → prompt_id), lang-tag token ids |
+
+## Streaming / cache-aware I/O
+
+- Chunk: `chunk_mel_frames=112` (+`pre_encode_cache=9` → `total_mel_frames=121`), `att_context_size=[56,0]`.
+- Encoder cache carried across chunks: `cache_channel [1,24,56,1024]`, `cache_time [1,24,1024,8]`, `cache_len [1]`.
+- Language is selected per chunk via an integer `prompt_id` (see `prompt_dictionary` in `metadata.json`; `auto` = 101).
+- The 39 language-tag token ids in `metadata.json["lang_tag_token_ids"]` are stripped from the decoded text.
+
+## Accuracy (FLEURS, full test splits, FP32, greedy, forced language)
+
+Measured on the OpenVINO IR (CPU). Reference column is the FluidAudio CoreML build of the same base model.
+
+| Lang | Metric | OpenVINO | FluidAudio ref | Δ | n |
+|------|--------|---------:|---------------:|------:|----:|
+| en_us | WER | **11.78** | 12.09 | −0.31 | 647 |
+| es_419 | WER | **6.99** | 9.01 | −2.02 | 908 |
+| fr_fr | WER | **12.92** | 15.18 | −2.26 | 676 |
+| cmn_hans_cn | CER | **21.05** | 24.54 | −3.49 | 945 |
+| ja_jp | CER | **15.12** | 16.86 | −1.74 | 650 |
+| **weighted** | mixed | **13.70** | 15.79 | **−2.09** | 3826 |
+
+The export matches or beats the reference on every language — no conversion regression.
+FP16 produces transcripts identical to FP32.
+
+Throughput: **RTFx ≈ 3.66×** audio-weighted on a single CPU (Intel Xeon E5-2699 v4, 4 vCPU);
+higher on Intel NPU / iGPU.
+
+## INT8 weight-only (`int8/`)
+
+Weight-only INT8 compression of the **encoder** (per-channel symmetric, data-free — mirrors
+the CoreML `linear_quantize_weights` build). Only the weight constants become int8 with fp16
+scales; activations stay fp16. The 24 Conformer relative-position projections
+(`self_attn.linear_pos`) are kept FP16 — int8-compressing them trips an OpenVINO CPU compile
+bug and they carry little weight mass. Decoder / joint / preprocessor stay FP16.
+
+Measured on the **same FLEURS full test splits, forced language, greedy** — directly comparable
+to the FP32 table above:
+
+| Lang | Metric | FP32 | INT8-wo | Δ | n |
+|------|--------|-----:|--------:|------:|----:|
+| en_us | WER | 11.78 | **11.93** | +0.15 | 647 |
+| es_419 | WER | 6.99 | **7.05** | +0.06 | 908 |
+| fr_fr | WER | 12.92 | **12.99** | +0.07 | 676 |
+| cmn_hans_cn | CER | 21.05 | **20.94** | −0.11 | 945 |
+| ja_jp | CER | 15.12 | **15.15** | +0.03 | 650 |
+| **weighted** | mixed | 13.70 | **13.73** | **+0.03** | 3826 |
+
+Essentially lossless — the largest swing is +0.15 WER (within run-to-run noise) and Chinese
+CER improves slightly.
+
+**What INT8 buys you — and what it doesn't:**
+
+| | FP32 | FP16 | INT8-wo |
+|---|---:|---:|---:|
+| encoder `.bin` | 2.5 GB | 1.25 GB | **732 MB** |
+| folder size | ~2.5 GB | ~1.3 GB | **~749 MB** |
+| peak RSS (CPU) | 5.8 GB | 3.9 GB | **2.1 GB** |
+| RTFx (audio-wtd, 4 vCPU) | 3.66× | ≈3.66× | **2.96×** |
+
+INT8 is a **memory / disk** win (~½ the RAM of FP16), not a speed win: on x86 CPU the int8
+weights decompress to float per-op, so it runs *slower* than FP16. The speed payoff is on
+**Intel NPU**, where native int8 execution applies. Choose `int8/` for memory-constrained or
+NPU deployments; choose `fp16/` for fastest CPU inference.
+
+## License
+
+Inherits `openmdw-1.1` from the base model. See the base model card for terms.

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_ov.py
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_ov.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""CPU benchmark for the Nemotron OpenVINO IR: latency, RTFx, per-component.
+
+Times end-to-end streaming transcription over N runs for a given IR dir,
+plus a per-component breakdown (preprocessor/encoder/decoder/joint). Reports
+real-time factor (audio_seconds / wall_seconds).
+"""
+import argparse
+import time
+
+import numpy as np
+import soundfile as sf
+
+from transcribe_ov import NemotronOV
+
+
+def bench(model_dir, audio, sr, target_lang, runs):
+    r = NemotronOV(model_dir, device="CPU")
+    dur = len(audio) / sr
+    # warmup
+    r.transcribe_streaming(audio, target_lang=target_lang)
+    times = []
+    for _ in range(runs):
+        t0 = time.perf_counter()
+        _, text, _ = r.transcribe_streaming(audio, target_lang=target_lang)
+        times.append(time.perf_counter() - t0)
+    times = np.array(times)
+    return dur, times, text
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model-dir", required=True)
+    ap.add_argument("--audio", required=True)
+    ap.add_argument("--target-lang", default="en-US")
+    ap.add_argument("--runs", type=int, default=5)
+    args = ap.parse_args()
+
+    audio, sr = sf.read(args.audio, dtype="float32")
+    if audio.ndim > 1:
+        audio = audio.mean(axis=1)
+    dur, times, text = bench(args.model_dir, audio, sr, args.target_lang, args.runs)
+
+    mean_s = times.mean()
+    print(f"\n=== {args.model_dir} ===")
+    print(f"audio:    {dur:.2f}s")
+    print(f"runs:     {args.runs}")
+    print(f"latency:  mean {mean_s*1000:.0f} ms | min {times.min()*1000:.0f} | max {times.max()*1000:.0f}")
+    print(f"RTFx:     {dur/mean_s:.1f}x  (audio_sec / wall_sec)")
+    print(f"text:     {text[:80]}...")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/int8_full_en_us.json
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/int8_full_en_us.json
@@ -1,0 +1,15 @@
+{
+  "mode": "forced",
+  "results": [
+    {
+      "fleurs_lang": "en_us",
+      "nemo_lang": "en-US",
+      "files": 647,
+      "metric": "WER",
+      "value": 18.72,
+      "rtfx": 2.98,
+      "detect_acc": null,
+      "audio_seconds": 6387.9
+    }
+  ]
+}

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/int8_full_es_419.json
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/int8_full_es_419.json
@@ -1,0 +1,15 @@
+{
+  "mode": "forced",
+  "results": [
+    {
+      "fleurs_lang": "es_419",
+      "nemo_lang": "es-ES",
+      "files": 908,
+      "metric": "WER",
+      "value": 8.29,
+      "rtfx": 2.99,
+      "detect_acc": null,
+      "audio_seconds": 11126.1
+    }
+  ]
+}

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/int8_full_fr_fr.json
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/int8_full_fr_fr.json
@@ -1,0 +1,15 @@
+{
+  "mode": "forced",
+  "results": [
+    {
+      "fleurs_lang": "fr_fr",
+      "nemo_lang": "fr-FR",
+      "files": 676,
+      "metric": "WER",
+      "value": 15.48,
+      "rtfx": 3.01,
+      "detect_acc": null,
+      "audio_seconds": 7024.1
+    }
+  ]
+}

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/int8wo_en_smoke.json
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/int8wo_en_smoke.json
@@ -1,0 +1,15 @@
+{
+  "mode": "forced",
+  "results": [
+    {
+      "fleurs_lang": "en_us",
+      "nemo_lang": "en-US",
+      "files": 150,
+      "metric": "WER",
+      "value": 10.99,
+      "rtfx": 2.59,
+      "detect_acc": null,
+      "audio_seconds": 1415.4
+    }
+  ]
+}

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/int8wo_full_cmn_hans_cn.json
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/int8wo_full_cmn_hans_cn.json
@@ -1,0 +1,15 @@
+{
+  "mode": "forced",
+  "results": [
+    {
+      "fleurs_lang": "cmn_hans_cn",
+      "nemo_lang": "zh-CN",
+      "files": 945,
+      "metric": "CER",
+      "value": 20.94,
+      "rtfx": 2.73,
+      "detect_acc": null,
+      "audio_seconds": 11065.2
+    }
+  ]
+}

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/int8wo_full_en_us.json
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/int8wo_full_en_us.json
@@ -1,0 +1,15 @@
+{
+  "mode": "forced",
+  "results": [
+    {
+      "fleurs_lang": "en_us",
+      "nemo_lang": "en-US",
+      "files": 647,
+      "metric": "WER",
+      "value": 11.93,
+      "rtfx": 2.55,
+      "detect_acc": null,
+      "audio_seconds": 6387.9
+    }
+  ]
+}

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/int8wo_full_es_419.json
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/int8wo_full_es_419.json
@@ -1,0 +1,15 @@
+{
+  "mode": "forced",
+  "results": [
+    {
+      "fleurs_lang": "es_419",
+      "nemo_lang": "es-ES",
+      "files": 908,
+      "metric": "WER",
+      "value": 7.05,
+      "rtfx": 3.05,
+      "detect_acc": null,
+      "audio_seconds": 11126.1
+    }
+  ]
+}

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/int8wo_full_fr_fr.json
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/int8wo_full_fr_fr.json
@@ -1,0 +1,15 @@
+{
+  "mode": "forced",
+  "results": [
+    {
+      "fleurs_lang": "fr_fr",
+      "nemo_lang": "fr-FR",
+      "files": 676,
+      "metric": "WER",
+      "value": 12.99,
+      "rtfx": 2.74,
+      "detect_acc": null,
+      "audio_seconds": 7024.1
+    }
+  ]
+}

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/int8wo_full_ja_jp.json
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/int8wo_full_ja_jp.json
@@ -1,0 +1,15 @@
+{
+  "mode": "forced",
+  "results": [
+    {
+      "fleurs_lang": "ja_jp",
+      "nemo_lang": "ja-JP",
+      "files": 650,
+      "metric": "CER",
+      "value": 15.15,
+      "rtfx": 4.03,
+      "detect_acc": null,
+      "audio_seconds": 8511.1
+    }
+  ]
+}

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/ov_fleurs_en_fp32_n100.json
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/ov_fleurs_en_fp32_n100.json
@@ -1,0 +1,15 @@
+{
+  "mode": "forced",
+  "results": [
+    {
+      "fleurs_lang": "en_us",
+      "nemo_lang": "en-US",
+      "files": 100,
+      "metric": "WER",
+      "value": 10.95,
+      "rtfx": 3.72,
+      "detect_acc": null,
+      "audio_seconds": 953.9
+    }
+  ]
+}

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/ov_full_cmn_hans_cn.json
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/ov_full_cmn_hans_cn.json
@@ -1,0 +1,15 @@
+{
+  "mode": "forced",
+  "results": [
+    {
+      "fleurs_lang": "cmn_hans_cn",
+      "nemo_lang": "zh-CN",
+      "files": 945,
+      "metric": "CER",
+      "value": 21.05,
+      "rtfx": 3.75,
+      "detect_acc": null,
+      "audio_seconds": 11065.2
+    }
+  ]
+}

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/ov_full_en_us.json
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/ov_full_en_us.json
@@ -1,0 +1,15 @@
+{
+  "mode": "forced",
+  "results": [
+    {
+      "fleurs_lang": "en_us",
+      "nemo_lang": "en-US",
+      "files": 647,
+      "metric": "WER",
+      "value": 11.78,
+      "rtfx": 3.63,
+      "detect_acc": null,
+      "audio_seconds": 6387.9
+    }
+  ]
+}

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/ov_full_es_419.json
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/ov_full_es_419.json
@@ -1,0 +1,15 @@
+{
+  "mode": "forced",
+  "results": [
+    {
+      "fleurs_lang": "es_419",
+      "nemo_lang": "es-ES",
+      "files": 908,
+      "metric": "WER",
+      "value": 6.99,
+      "rtfx": 3.81,
+      "detect_acc": null,
+      "audio_seconds": 11126.1
+    }
+  ]
+}

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/ov_full_fr_fr.json
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/ov_full_fr_fr.json
@@ -1,0 +1,15 @@
+{
+  "mode": "forced",
+  "results": [
+    {
+      "fleurs_lang": "fr_fr",
+      "nemo_lang": "fr-FR",
+      "files": 676,
+      "metric": "WER",
+      "value": 12.92,
+      "rtfx": 3.57,
+      "detect_acc": null,
+      "audio_seconds": 7024.1
+    }
+  ]
+}

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/ov_full_ja_jp.json
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/bench_results/ov_full_ja_jp.json
@@ -1,0 +1,15 @@
+{
+  "mode": "forced",
+  "results": [
+    {
+      "fleurs_lang": "ja_jp",
+      "nemo_lang": "ja-JP",
+      "files": 650,
+      "metric": "CER",
+      "value": 15.12,
+      "rtfx": 3.45,
+      "detect_acc": null,
+      "audio_seconds": 8511.1
+    }
+  ]
+}

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/benchmark_fleurs_ov.py
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/benchmark_fleurs_ov.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""
+FLEURS multilingual benchmark for Nemotron Multilingual Streaming 0.6B.
+
+Runs the CoreML pipeline across one or more FLEURS test subsets and reports:
+
+  - WER (Latin-script langs) or CER (CJK / Thai)
+  - Detection accuracy when `--mode auto` is used (does the leading
+    <xx-XX> token match the FLEURS subset label?)
+  - RTFx (real-time factor) per language
+
+Reuses `NemotronMultilingualCoreML` from `test_coreml_multilingual.py`
+unchanged, so the inference path is byte-identical to the smoke test.
+
+Two ways to provide FLEURS:
+
+  1. `--use-hf`              — stream the dataset via `datasets` from
+                               `google/fleurs`. Requires `pip install datasets`.
+  2. `--fleurs-root <dir>`   — point at a local FLEURS download with
+                               <lang>/test/*.wav + <lang>/test.tsv.
+
+Example:
+
+    uv run python benchmark_fleurs.py \\
+        --model-dir ./build_fp16 \\
+        --use-hf \\
+        --languages cmn_hans_cn,en_us,es_419 \\
+        --mode auto \\
+        --max-files-per-lang 100
+"""
+import argparse
+import csv
+import json
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Iterable, Iterator, List, Optional, Tuple
+
+import numpy as np
+
+# Reuse the inference class verbatim
+sys.path.insert(0, str(Path(__file__).parent))
+from transcribe_ov import NemotronOV as NemotronMultilingualCoreML
+from fleurs_lang_map import fleurs_to_nemotron, uses_cer  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Text normalization + scoring
+# ---------------------------------------------------------------------------
+
+_PUNCT_RE = re.compile(r"[^\w\s\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\u0e00-\u0e7f]")
+
+
+def normalize(text: str) -> str:
+    """Lowercase, strip punctuation, collapse whitespace. CJK/Thai chars kept."""
+    text = text.lower()
+    text = _PUNCT_RE.sub(" ", text)
+    return " ".join(text.split())
+
+
+def _edit_distance(ref: List[str], hyp: List[str]) -> int:
+    n, m = len(ref), len(hyp)
+    if n == 0:
+        return m
+    if m == 0:
+        return n
+    d = np.zeros((n + 1, m + 1), dtype=np.uint32)
+    d[:, 0] = np.arange(n + 1)
+    d[0, :] = np.arange(m + 1)
+    for i in range(1, n + 1):
+        for j in range(1, m + 1):
+            cost = 0 if ref[i - 1] == hyp[j - 1] else 1
+            d[i, j] = min(d[i - 1, j] + 1, d[i, j - 1] + 1, d[i - 1, j - 1] + cost)
+    return int(d[n, m])
+
+
+def score(reference: str, hypothesis: str, use_cer: bool) -> Tuple[int, int]:
+    ref = normalize(reference)
+    hyp = normalize(hypothesis)
+    if use_cer:
+        ref_units = [c for c in ref if not c.isspace()]
+        hyp_units = [c for c in hyp if not c.isspace()]
+    else:
+        ref_units = ref.split()
+        hyp_units = hyp.split()
+    return _edit_distance(ref_units, hyp_units), len(ref_units)
+
+
+# ---------------------------------------------------------------------------
+# FLEURS loaders — two backends with the same iterator contract
+# ---------------------------------------------------------------------------
+
+def _iter_fleurs_hf(lang: str, max_files: Optional[int]) -> Iterator[Tuple[str, np.ndarray, int, str]]:
+    """Yield (utt_id, audio_float32, sr, reference) from `google/fleurs`.
+
+    Uses `Audio(decode=False)` + soundfile because the default
+    decode path requires torchcodec, which is not in the slim macOS
+    inference env.
+    """
+    try:
+        from datasets import load_dataset, Audio
+    except ImportError as e:
+        raise SystemExit(
+            "datasets package not installed; run `uv add datasets` or pass --fleurs-root"
+        ) from e
+    import io
+    import os
+    import soundfile as sf
+    _stream = bool(int(os.environ.get("FLEURS_STREAMING", "0")))
+    ds = load_dataset("google/fleurs", lang, split="test", streaming=_stream)
+    ds = ds.cast_column("audio", Audio(decode=False))
+    for i, ex in enumerate(ds):
+        if max_files and i >= max_files:
+            break
+        audio_bytes = ex["audio"]["bytes"]
+        audio, sr = sf.read(io.BytesIO(audio_bytes), dtype="float32")
+        if audio.ndim > 1:
+            audio = audio.mean(axis=1)
+        yield str(ex.get("id", i)), audio, int(sr), ex["transcription"]
+
+
+def _iter_fleurs_local(
+    fleurs_root: Path, lang: str, max_files: Optional[int]
+) -> Iterator[Tuple[str, np.ndarray, int, str]]:
+    """Yield from a local FLEURS layout: <root>/<lang>/test/*.wav + test.tsv."""
+    import soundfile as sf
+    tsv = fleurs_root / lang / "test.tsv"
+    if not tsv.exists():
+        raise SystemExit(f"missing {tsv} — check --fleurs-root layout")
+    audio_dir = fleurs_root / lang / "audio" / "test"
+    if not audio_dir.exists():
+        # Fall back to flat layout
+        audio_dir = fleurs_root / lang / "test"
+    with open(tsv, newline="") as f:
+        rows = list(csv.reader(f, delimiter="\t"))
+    for i, row in enumerate(rows):
+        if max_files and i >= max_files:
+            break
+        if len(row) < 3:
+            continue
+        # FLEURS test.tsv columns: id, raw_transcription, normalized_transcription, num_samples, gender
+        utt_id, _raw, ref = row[0], row[1], row[2]
+        wav = audio_dir / f"{utt_id}.wav"
+        if not wav.exists():
+            wav = audio_dir / f"{utt_id}.flac"
+        if not wav.exists():
+            continue
+        audio, sr = sf.read(str(wav), dtype="float32")
+        if audio.ndim > 1:
+            audio = audio.mean(axis=1)
+        yield utt_id, audio, int(sr), ref
+
+
+def iter_fleurs(
+    lang: str,
+    use_hf: bool,
+    fleurs_root: Optional[Path],
+    max_files: Optional[int],
+) -> Iterator[Tuple[str, np.ndarray, int, str]]:
+    if use_hf:
+        yield from _iter_fleurs_hf(lang, max_files)
+    else:
+        if fleurs_root is None:
+            raise SystemExit("Pass either --use-hf or --fleurs-root")
+        yield from _iter_fleurs_local(fleurs_root, lang, max_files)
+
+
+def maybe_resample(audio: np.ndarray, sr: int, target_sr: int = 16000) -> np.ndarray:
+    if sr == target_sr:
+        return audio
+    try:
+        from scipy.signal import resample_poly
+    except ImportError as e:
+        raise SystemExit(
+            "scipy required for resampling; install it or pre-resample audio"
+        ) from e
+    from math import gcd
+    g = gcd(sr, target_sr)
+    return resample_poly(audio, target_sr // g, sr // g).astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# Per-language run
+# ---------------------------------------------------------------------------
+
+def run_lang(
+    runner: NemotronMultilingualCoreML,
+    fleurs_lang: str,
+    nemo_lang: str,
+    mode: str,
+    use_hf: bool,
+    fleurs_root: Optional[Path],
+    max_files: Optional[int],
+) -> dict:
+    use_cer = uses_cer(nemo_lang)
+    metric = "CER" if use_cer else "WER"
+
+    total_errors = 0
+    total_units = 0
+    correct_detections = 0
+    detection_attempts = 0
+    audio_secs = 0.0
+    compute_secs = 0.0
+    expected_tag = f"<{nemo_lang}>"
+
+    print(f"\n[{fleurs_lang} → {nemo_lang}]  metric={metric}  mode={mode}")
+
+    n = 0
+    for utt_id, audio, sr, ref in iter_fleurs(fleurs_lang, use_hf, fleurs_root, max_files):
+        audio = maybe_resample(audio, sr, 16000)
+        audio_secs += len(audio) / 16000.0
+
+        target_lang = nemo_lang if mode == "forced" else "auto"
+        t0 = time.perf_counter()
+        detected_tag, hyp, _pid = runner.transcribe_streaming(audio, target_lang=target_lang)
+        compute_secs += time.perf_counter() - t0
+
+        if mode == "auto":
+            detection_attempts += 1
+            if detected_tag == expected_tag:
+                correct_detections += 1
+
+        errors, units = score(ref, hyp, use_cer)
+        total_errors += errors
+        total_units += units
+        n += 1
+
+        if n <= 3:
+            print(f"   [{n}] {utt_id}  errs={errors}/{units}  det={detected_tag}")
+            print(f"       REF: {ref[:80]}")
+            print(f"       HYP: {hyp[:80]}")
+
+    if total_units == 0:
+        return {"lang": fleurs_lang, "files": 0, "metric": metric, "value": None}
+
+    score_pct = 100.0 * total_errors / total_units
+    rtfx = audio_secs / compute_secs if compute_secs > 0 else float("inf")
+    det_acc = (
+        100.0 * correct_detections / detection_attempts if detection_attempts else None
+    )
+
+    print(
+        f"   files={n} {metric}={score_pct:.2f}%  RTFx={rtfx:.2f}x"
+        + (f"  detect_acc={det_acc:.1f}%" if det_acc is not None else "")
+    )
+
+    return {
+        "fleurs_lang": fleurs_lang,
+        "nemo_lang": nemo_lang,
+        "files": n,
+        "metric": metric,
+        "value": round(score_pct, 2),
+        "rtfx": round(rtfx, 2),
+        "detect_acc": round(det_acc, 1) if det_acc is not None else None,
+        "audio_seconds": round(audio_secs, 1),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="Nemotron Multilingual FLEURS benchmark")
+    parser.add_argument("--model-dir", type=str, required=True,
+                        help="Directory with the 4 .mlpackages + metadata.json + tokenizer.json")
+    parser.add_argument("--languages", type=str, required=True,
+                        help="Comma-separated FLEURS lang codes, e.g. cmn_hans_cn,en_us,es_419")
+    parser.add_argument("--mode", choices=["forced", "auto"], default="auto",
+                        help='"forced": pass the per-utterance language as prompt; '
+                             '"auto": always pass prompt 101 (default)')
+    parser.add_argument("--max-files-per-lang", type=int, default=None,
+                        help="Cap files per language for quick runs")
+    parser.add_argument("--use-hf", action="store_true",
+                        help="Load FLEURS via datasets.load_dataset('google/fleurs', ...)")
+    parser.add_argument("--fleurs-root", type=str, default=None,
+                        help="Local FLEURS root directory (alternative to --use-hf)")
+    parser.add_argument("--output-json", type=str, default=None,
+                        help="Write per-language results to this JSON file")
+    args = parser.parse_args()
+
+    print("=" * 70)
+    print("NEMOTRON MULTILINGUAL — FLEURS BENCHMARK")
+    print("=" * 70)
+    print(f"model_dir: {args.model_dir}")
+    print(f"mode:      {args.mode}")
+    print(f"max/lang:  {args.max_files_per_lang}")
+
+    runner = NemotronMultilingualCoreML(args.model_dir)
+
+    lang_codes = [l.strip() for l in args.languages.split(",") if l.strip()]
+    fleurs_root = Path(args.fleurs_root) if args.fleurs_root else None
+
+    results = []
+    for fleurs_lang in lang_codes:
+        nemo_lang = fleurs_to_nemotron(fleurs_lang)
+        if nemo_lang is None:
+            print(f"\n[skip] {fleurs_lang}: no Nemotron prompt mapping")
+            continue
+        r = run_lang(
+            runner=runner,
+            fleurs_lang=fleurs_lang,
+            nemo_lang=nemo_lang,
+            mode=args.mode,
+            use_hf=args.use_hf,
+            fleurs_root=fleurs_root,
+            max_files=args.max_files_per_lang,
+        )
+        results.append(r)
+
+    print("\n" + "=" * 70)
+    print(f"SUMMARY (mode={args.mode})")
+    print("=" * 70)
+    header = f"{'fleurs':<14} {'nemo':<8} {'n':>4} {'metric':<6} {'score':>7} {'RTFx':>6} {'det%':>6}"
+    print(header)
+    print("-" * len(header))
+    for r in results:
+        det = f"{r['detect_acc']:.1f}" if r.get("detect_acc") is not None else "-"
+        val = f"{r['value']:.2f}" if r.get("value") is not None else "-"
+        print(f"{r['fleurs_lang']:<14} {r['nemo_lang']:<8} {r['files']:>4} "
+              f"{r['metric']:<6} {val:>7} {r['rtfx']:>6.2f} {det:>6}")
+
+    if args.output_json:
+        Path(args.output_json).write_text(json.dumps(
+            {"mode": args.mode, "results": results}, indent=2, ensure_ascii=False
+        ))
+        print(f"\nWrote {args.output_json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/export_openvino.py
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/export_openvino.py
@@ -32,6 +32,8 @@ from typing import List, Tuple
 
 import numpy as np
 import openvino as ov
+import openvino.runtime.opset13 as _ovops
+from openvino.runtime.utils import replace_node as _ov_replace_node
 import torch
 import typer
 
@@ -74,6 +76,27 @@ def _lang_tag_token_ids(model) -> List[int]:
     return ids
 
 
+def _make_npu_safe(ov_model: ov.Model) -> int:
+    """Rewrite BitwiseNot(bool) -> LogicalNot so the IR runs on the OpenVINO NPU.
+
+    The NPU plugin miscompiles BitwiseNot on a boolean tensor: it performs an
+    integer bitwise complement, so ~0 = -1 and ~1 = -2 are *both* nonzero
+    ("true"). The FastConformer attention mask is built with `~` over a bool, so
+    on NPU the mask becomes all-true -> every key masked -> uniform softmax ->
+    the encoder output collapses to ~0 and every transcript is empty. LogicalNot
+    is semantically identical on a boolean and compiles correctly on NPU; it is a
+    no-op for CPU/GPU correctness. Returns the number of nodes rewritten.
+    """
+    n = 0
+    for op in list(ov_model.get_ordered_ops()):
+        if op.get_type_name() == "BitwiseNot":
+            repl = _ovops.logical_not(op.input_value(0))
+            repl.get_output_tensor(0).set_names(op.get_output_tensor(0).get_names())
+            _ov_replace_node(op, repl)
+            n += 1
+    return n
+
+
 def _save_ir(
     traced: torch.jit.ScriptModule,
     example_input: tuple,
@@ -94,6 +117,9 @@ def _save_ir(
         port.get_tensor().set_names({name})
     for port, name in zip(ov_model.outputs, output_names):
         port.get_tensor().set_names({name})
+    n_fixed = _make_npu_safe(ov_model)
+    if n_fixed:
+        print(f"  NPU-safe: rewrote {n_fixed} BitwiseNot -> LogicalNot")
     ov_model.validate_nodes_and_infer_types()
     ov.save_model(ov_model, str(out_path), compress_to_fp16=fp16)
     print(f"  saved {out_path.name}  inputs={[i.get_any_name() for i in ov_model.inputs]}"

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/export_openvino.py
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/export_openvino.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Export Nemotron-3.5-ASR-Streaming-Multilingual 0.6B to OpenVINO IR.
+
+This is the OpenVINO analogue of mobius's CoreML conversion
+(`convert_nemotron_multilingual.py`). It reuses the *exact same* traceable
+TorchScript wrappers from the mobius CoreML pipeline — the wrappers are
+backend-agnostic — and only swaps the backend call:
+
+    CoreML:   ct.convert(traced, inputs=..., outputs=...)
+    OpenVINO: ov.convert_model(traced, example_input=...) + ov.save_model
+
+Produces, in --output-dir, the four IR pairs eddy-audio consumes plus
+tokenizer/metadata:
+
+    nemotron_preprocessor.xml/.bin   audio -> mel
+    nemotron_encoder.xml/.bin        mel + caches + prompt_id -> encoded + caches
+    nemotron_decoder.xml/.bin        token + lstm state -> dec_out + state
+    nemotron_joint.xml/.bin          enc_step + dec_step -> logits
+    nemotron_vocab.json              id -> token piece
+    metadata.json                    shapes, blank_idx, prompt_dictionary, ...
+
+Run:
+    python export_openvino.py --nemo-path ./nemotron-3.5-asr-streaming-0.6b.nemo \
+        --output-dir ./build_ov --precision FP32 --att-context 56,0
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+import numpy as np
+import openvino as ov
+import torch
+import typer
+
+# Reuse the mobius CoreML wrappers verbatim (backend-agnostic TorchScript).
+_MOBIUS = Path.home() / "mobius" / "models" / "stt"
+_EN_PKG = _MOBIUS / "nemotron-speech-streaming-0.6b" / "coreml" / "conversion_scripts"
+_ML_PKG = _MOBIUS / "nemotron-asr-streaming-multilingual-0.6b" / "coreml" / "conversion_scripts"
+sys.path.insert(0, str(_EN_PKG))
+sys.path.insert(0, str(_ML_PKG))
+
+from individual_components import (  # type: ignore  # noqa: E402
+    DecoderWrapper,
+    JointWrapper,
+    PreprocessorWrapper,
+)
+from multilingual_components import (  # type: ignore  # noqa: E402
+    EncoderStreamingWithPostPrompt,
+    NUM_PROMPTS,
+)
+
+_LANG_TAG_RE = __import__("re").compile(r"^<[A-Za-z]{2,4}-[A-Za-z]{2,4}>$")
+
+
+def _shape(t: torch.Tensor) -> Tuple[int, ...]:
+    return tuple(int(d) for d in t.shape)
+
+
+def _parse_att_context(s: str) -> List[int]:
+    parts = [p.strip() for p in s.split(",")]
+    if len(parts) != 2:
+        raise typer.BadParameter("--att-context must be 'left,right' e.g. '56,0'")
+    return [int(parts[0]), int(parts[1])]
+
+
+def _lang_tag_token_ids(model) -> List[int]:
+    ids: List[int] = []
+    for i in range(int(model.tokenizer.vocab_size)):
+        if _LANG_TAG_RE.match(model.tokenizer.ids_to_tokens([i])[0]):
+            ids.append(i)
+    return ids
+
+
+def _save_ir(
+    traced: torch.jit.ScriptModule,
+    example_input: tuple,
+    input_specs: List[tuple],   # (name, [shape], dtype)
+    output_names: List[str],
+    out_path: Path,
+    fp16: bool,
+) -> None:
+    """OpenVINO equivalent of mobius's `_coreml_convert` + `.save`."""
+    inputs = [(name, shape, dtype) for (name, shape, dtype) in input_specs]
+    ov_model = ov.convert_model(
+        traced,
+        example_input=example_input,
+        input=[(s[1], s[2]) for s in inputs],
+    )
+    # Name the I/O so eddy can resolve ports by name.
+    for port, (name, _, _) in zip(ov_model.inputs, inputs):
+        port.get_tensor().set_names({name})
+    for port, name in zip(ov_model.outputs, output_names):
+        port.get_tensor().set_names({name})
+    ov_model.validate_nodes_and_infer_types()
+    ov.save_model(ov_model, str(out_path), compress_to_fp16=fp16)
+    print(f"  saved {out_path.name}  inputs={[i.get_any_name() for i in ov_model.inputs]}"
+          f"  outputs={[o.get_any_name() for o in ov_model.outputs]}")
+
+
+app = typer.Typer(add_completion=False, pretty_exceptions_show_locals=False)
+
+
+@app.command()
+def convert(
+    nemo_path: Path = typer.Option(..., "--nemo-path"),
+    output_dir: Path = typer.Option(Path("build_ov"), "--output-dir"),
+    precision: str = typer.Option("FP32", "--precision", help="FP32 or FP16"),
+    att_context: str = typer.Option("56,0", "--att-context"),
+    chunk_mel_frames: int = typer.Option(112, "--chunk-mel-frames"),
+    pre_encode_cache: int = typer.Option(9, "--pre-encode-cache"),
+) -> None:
+    import nemo.collections.asr as nemo_asr
+
+    fp16 = precision.upper() == "FP16"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Loading model from {nemo_path} ...")
+    model = nemo_asr.models.ASRModel.restore_from(
+        restore_path=str(nemo_path), map_location="cpu"
+    )
+    model.eval()
+    model_class = f"{type(model).__module__}.{type(model).__name__}"
+    print(f"  class: {model_class}")
+    if not hasattr(model, "prompt_kernel"):
+        raise RuntimeError("No prompt_kernel; wrong checkpoint?")
+
+    sample_rate = int(model.cfg.preprocessor.sample_rate)
+    mel_features = int(model.cfg.preprocessor.features)
+
+    encoder = model.encoder
+    parsed_att = _parse_att_context(att_context)
+    encoder.att_context_size = list(parsed_att)
+    encoder.setup_streaming_params(att_context_size=parsed_att)
+
+    cache_channel, cache_time, cache_len = encoder.get_initial_cache_state(
+        batch_size=1, device="cpu"
+    )
+    cache_len = cache_len.to(torch.int32)
+    cache_channel_b = cache_channel.transpose(0, 1)
+    cache_time_b = cache_time.transpose(0, 1)
+    print(f"  caches: channel={_shape(cache_channel_b)} time={_shape(cache_time_b)} "
+          f"len={_shape(cache_len)}")
+
+    encoder_streaming = EncoderStreamingWithPostPrompt(
+        encoder.eval(), model.prompt_kernel.eval(), num_prompts=NUM_PROMPTS
+    )
+    preprocessor = PreprocessorWrapper(model.preprocessor.eval())
+    decoder = DecoderWrapper(model.decoder.eval())
+    joint = JointWrapper(model.joint.eval())
+    model.decoder._rnnt_export = True
+
+    total_mel_frames = chunk_mel_frames + pre_encode_cache
+    max_samples = int(30.0 * sample_rate)
+
+    # === 1. Preprocessor (dynamic audio length) ===
+    print("Exporting preprocessor ...")
+    audio = torch.randn(1, max_samples)
+    traced = torch.jit.trace(
+        preprocessor, (audio, torch.tensor([max_samples], dtype=torch.int32)), strict=False
+    )
+    _save_ir(
+        traced,
+        (audio, torch.tensor([max_samples], dtype=torch.int32)),
+        [("audio", [1, -1], ov.Type.f32), ("audio_length", [1], ov.Type.i32)],
+        ["mel", "mel_length"],
+        output_dir / "nemotron_preprocessor.xml",
+        fp16,
+    )
+
+    # === 2. Encoder (prompt-aware streaming, fixed chunk) ===
+    print("Exporting encoder ...")
+    mel = torch.randn(1, mel_features, total_mel_frames)
+    mel_len = torch.tensor([total_mel_frames], dtype=torch.int32)
+    prompt_id = torch.tensor([0], dtype=torch.int32)
+    enc_ex = (mel, mel_len, cache_channel_b, cache_time_b, cache_len, prompt_id)
+    traced = torch.jit.trace(encoder_streaming, enc_ex, strict=False)
+    _save_ir(
+        traced,
+        enc_ex,
+        [
+            ("mel", list(_shape(mel)), ov.Type.f32),
+            ("mel_length", [1], ov.Type.i32),
+            ("cache_channel", list(_shape(cache_channel_b)), ov.Type.f32),
+            ("cache_time", list(_shape(cache_time_b)), ov.Type.f32),
+            ("cache_len", [1], ov.Type.i32),
+            ("prompt_id", [1], ov.Type.i32),
+        ],
+        ["encoded", "encoded_length", "cache_channel_out", "cache_time_out", "cache_len_out"],
+        output_dir / "nemotron_encoder.xml",
+        fp16,
+    )
+
+    # === 3. Decoder (RNNT prediction, single step) ===
+    print("Exporting decoder ...")
+    dec_hidden = int(model.decoder.pred_hidden)
+    dec_layers = int(model.decoder.pred_rnn_layers)
+    targets = torch.tensor([[model.decoder.blank_idx]], dtype=torch.int32)
+    target_len = torch.tensor([1], dtype=torch.int32)
+    h = torch.zeros(dec_layers, 1, dec_hidden)
+    c = torch.zeros(dec_layers, 1, dec_hidden)
+    dec_ex = (targets, target_len, h, c)
+    traced = torch.jit.trace(decoder, dec_ex, strict=False)
+    _save_ir(
+        traced,
+        dec_ex,
+        [
+            ("token", [1, 1], ov.Type.i32),
+            ("token_length", [1], ov.Type.i32),
+            ("h_in", list(_shape(h)), ov.Type.f32),
+            ("c_in", list(_shape(c)), ov.Type.f32),
+        ],
+        ["decoder_out", "h_out", "c_out"],
+        output_dir / "nemotron_decoder.xml",
+        fp16,
+    )
+
+    # === 4. Joint (single step) ===
+    print("Exporting joint ...")
+    with torch.no_grad():
+        mel_test, _ = preprocessor(
+            audio[:, :sample_rate], torch.tensor([sample_rate], dtype=torch.int32)
+        )
+        cc, ct_, cl = encoder.get_initial_cache_state(batch_size=1, device="cpu")
+        enc_out, _, _, _, _ = encoder_streaming(
+            mel_test, torch.tensor([mel_test.shape[2]], dtype=torch.int32),
+            cc.transpose(0, 1), ct_.transpose(0, 1), cl.to(torch.int32), prompt_id,
+        )
+        dec_out, _, _ = decoder(targets, target_len, h, c)
+    enc_step = enc_out[:, :, :1].contiguous()
+    dec_step = dec_out[:, :, :1].contiguous()
+    joint_ex = (enc_step, dec_step)
+    traced = torch.jit.trace(joint, joint_ex, strict=False)
+    _save_ir(
+        traced,
+        joint_ex,
+        [
+            ("encoder", list(_shape(enc_step)), ov.Type.f32),
+            ("decoder", list(_shape(dec_step)), ov.Type.f32),
+        ],
+        ["logits"],
+        output_dir / "nemotron_joint.xml",
+        fp16,
+    )
+
+    # === 5. Vocab + metadata ===
+    vocab_size = int(model.tokenizer.vocab_size)
+    vocab = {str(i): model.tokenizer.ids_to_tokens([i])[0] for i in range(vocab_size)}
+    (output_dir / "nemotron_vocab.json").write_text(json.dumps(vocab, ensure_ascii=False, indent=2))
+
+    prompt_dict = dict(model.cfg.model_defaults.prompt_dictionary)
+    metadata = {
+        "model": "nvidia/nemotron-3.5-asr-streaming-0.6b",
+        "model_class": model_class,
+        "precision": precision.upper(),
+        "sample_rate": sample_rate,
+        "mel_features": mel_features,
+        "chunk_mel_frames": chunk_mel_frames,
+        "pre_encode_cache": pre_encode_cache,
+        "total_mel_frames": total_mel_frames,
+        "att_context_size": parsed_att,
+        "vocab_size": vocab_size,
+        "blank_idx": int(model.decoder.blank_idx),
+        "cache_channel_shape": list(cache_channel_b.shape),
+        "cache_time_shape": list(cache_time_b.shape),
+        "decoder_hidden": dec_hidden,
+        "decoder_layers": dec_layers,
+        "encoder_dim": int(enc_out.shape[1]),
+        "num_prompts": NUM_PROMPTS,
+        "prompt_dictionary": prompt_dict,
+        "default_prompt_id": prompt_dict.get("auto", 101),
+        "lang_tag_token_ids": _lang_tag_token_ids(model),
+    }
+    (output_dir / "metadata.json").write_text(json.dumps(metadata, indent=2))
+    print(f"Done. Exported OpenVINO IR to {output_dir}")
+
+
+if __name__ == "__main__":
+    app()

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/find_offenders.py
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/find_offenders.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+"""Find the minimal set of encoder MatMuls whose INT8 weight-compression
+breaks OV 2026.2.1 CPU compile, so we can exclude only those and compress
+everything else (near-full weight-only int8)."""
+import openvino as ov, nncf, sys
+core = ov.Core()
+SRC = "build_ov/nemotron_encoder.xml"
+m0 = core.read_model(SRC)
+mm = [op.get_friendly_name() for op in m0.get_ops()
+      if op.get_type_name() == "MatMul"
+      and any(op.input_value(i).get_node().get_type_name() == "Constant" for i in range(2))]
+print(f"compressible matmuls: {len(mm)}", flush=True)
+
+def compiles(compress_list, extra_ignore):
+    m = core.read_model(SRC)
+    ignore = [n for n in mm if n not in set(compress_list)] + list(extra_ignore)
+    q = nncf.compress_weights(m, mode=nncf.CompressWeightsMode.INT8_SYM,
+            ignored_scope=nncf.IgnoredScope(names=ignore))
+    try:
+        core.compile_model(q, "CPU"); return True
+    except Exception:
+        return False
+
+offenders = []
+# iteratively peel offenders: compress all matmuls except known offenders;
+# if it fails, bisect the prefix to find the first new offender.
+while True:
+    active = [n for n in mm if n not in set(offenders)]
+    if compiles(active, offenders):
+        print("ALL-CLEAR with offenders excluded:", offenders, flush=True)
+        break
+    # bisect prefix of `active`: find smallest k where compress(active[:k]) fails
+    lo, hi = 0, len(active)            # compiles(active[:0]) trivially true
+    # ensure full active fails (it does, since we're here)
+    while hi - lo > 1:
+        mid = (lo + hi) // 2
+        if compiles(active[:mid], offenders):
+            lo = mid
+        else:
+            hi = mid
+    bad = active[hi-1]
+    offenders.append(bad)
+    print(f"[offender #{len(offenders)}] idx-in-active={hi-1}: {bad}", flush=True)
+    if len(offenders) > 30:
+        print("too many offenders, aborting", flush=True); sys.exit(1)
+
+print("FINAL OFFENDERS:", offenders, flush=True)
+print(f"can compress {len(mm)-len(offenders)}/{len(mm)} matmuls", flush=True)

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/fleurs_lang_map.py
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/fleurs_lang_map.py
@@ -1,0 +1,79 @@
+"""
+FLEURS ↔ Nemotron language-code mapping.
+
+FLEURS uses `xx_yy` codes (e.g. "zh_cn", "es_419"); Nemotron's
+`prompt_dictionary` uses `xx-XX` (e.g. "zh-CN", "es-ES"). This module
+exposes a single dictionary and two small helpers.
+
+Only the 38 languages covered by both datasets are listed. FLEURS has
+more (~102); the extras have no Nemotron prompt and would just be
+returned with the `auto` prompt (id 101) if you try them.
+
+The list of Nemotron-supported codes comes from `metadata.json`'s
+`prompt_dictionary` (the 38 entries other than `auto`).
+
+Languages where the model emits no space-separated words (CJK, Thai,
+Lao, Burmese, Khmer, etc.) score via CER instead of WER. Set CER_LANGS
+accordingly.
+"""
+from typing import Optional
+
+# FLEURS-side code → Nemotron-side lang code.
+# When FLEURS has multiple variants of one Nemotron language (e.g. pt_br
+# and Nemotron only ships "pt-BR"), the FLEURS code maps to the one
+# Nemotron actually supports.
+FLEURS_TO_NEMOTRON = {
+    "en_us": "en-US",
+    "es_419": "es-ES",   # FLEURS Latin-American Spanish; closest prompt
+    "de_de": "de-DE",
+    "fr_fr": "fr-FR",
+    "it_it": "it-IT",
+    "ar_eg": "ar-EG",
+    "ja_jp": "ja-JP",
+    "ko_kr": "ko-KR",
+    "pt_br": "pt-BR",
+    "ru_ru": "ru-RU",
+    "hi_in": "hi-IN",
+    "cmn_hans_cn": "zh-CN",
+    "yue_hant_hk": "zh-TW",  # closest available; encoder still helps
+    "vi_vn": "vi-VN",
+    "he_il": "he-IL",
+    "nl_nl": "nl-NL",
+    "cs_cz": "cs-CZ",
+    "da_dk": "da-DK",
+    "pl_pl": "pl-PL",
+    "nb_no": "no-NO",
+    "sv_se": "sv-SE",
+    "th_th": "th-TH",
+    "tr_tr": "tr-TR",
+    "bg_bg": "bg-BG",
+    "el_gr": "el-GR",
+    "et_ee": "et-EE",
+    "fi_fi": "fi-FI",
+    "hr_hr": "hr-HR",
+    "hu_hu": "hu-HU",
+    "lt_lt": "lt-LT",
+    "lv_lv": "lv-LV",
+    "ro_ro": "ro-RO",
+    "sk_sk": "sk-SK",
+    "uk_ua": "uk-UA",
+    "mt_mt": "mt-MT",
+    "sl_si": "sl-SI",
+}
+
+# Languages where word-segmentation is unreliable or absent →
+# score via character error rate instead of word error rate.
+CER_LANGS = {
+    "zh-CN", "zh-TW",  # Mandarin (both scripts)
+    "ja-JP",
+    "th-TH",
+    "ko-KR",  # Korean: words exist but FLEURS reference spacing differs
+}
+
+
+def fleurs_to_nemotron(fleurs_code: str) -> Optional[str]:
+    return FLEURS_TO_NEMOTRON.get(fleurs_code.lower())
+
+
+def uses_cer(nemotron_lang: str) -> bool:
+    return nemotron_lang in CER_LANGS

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/nemo_reference.py
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/nemo_reference.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""
+NeMo Nemotron Multilingual Streaming Reference Implementation
+
+Streaming inference with nemotron-asr-streaming-multilingual-0.6b using 1.12s
+chunks. Identical to the English reference except for the language prompt:
+
+    - `target_lang` selects an integer `prompt_id` from `prompt_dictionary`.
+    - The encoder receives the prompt every chunk (constant per utterance).
+    - In "auto" mode (prompt 101) the model nominally emits a `<xx-XX>`
+      token identifying the spoken language; we try to surface it if
+      present, but it is in practice rarely emitted on short utterances
+      (see ARCHITECTURE.md "Auto mode and language tags" for the parity
+      data). Do not depend on `detected_lang` being non-None.
+
+There is no separate language-ID head — see ARCHITECTURE.md for the proof.
+"""
+import argparse
+import re
+from typing import Optional, Tuple
+
+import numpy as np
+import soundfile as sf
+import torch
+import nemo.collections.asr as nemo_asr
+from nemo.collections.asr.parts.utils.streaming_utils import CacheAwareStreamingAudioBuffer
+
+
+DEFAULT_MODEL_ID = "nvidia/nemotron-asr-streaming-multilingual-0.6b"
+LANG_TAG_RE = re.compile(r"^<[A-Za-z]{2,4}-[A-Za-z]{2,4}>$")
+
+
+def calc_drop_extra_pre_encoded(model, step_num: int, pad_and_drop_preencoded: bool) -> int:
+    if step_num == 0 and not pad_and_drop_preencoded:
+        return 0
+    return model.encoder.streaming_cfg.drop_extra_pre_encoded
+
+
+def _prompt_dictionary(model) -> dict:
+    """Canonical location for the prompt dictionary on the loaded model.
+
+    The dict is mirrored under several cfg subtrees but `model_defaults`
+    is what `set_inference_prompt` reads (see EncDecRNNTBPEModelWithPrompt).
+    """
+    md = getattr(model.cfg, "model_defaults", None)
+    if md is not None and "prompt_dictionary" in md:
+        return dict(md.prompt_dictionary)
+    return dict(getattr(model.cfg, "prompt_dictionary", {}) or {})
+
+
+def resolve_target_lang(model, target_lang: str) -> str:
+    """Resolve a user-supplied language code to one valid for the model.
+
+    Returns the canonical key used in `prompt_dictionary` (e.g. "en-US"
+    for inputs like "en"). Falls back to "auto" if the input cannot be
+    mapped — `set_inference_prompt` raises if it's still not in the dict.
+    """
+    pd = _prompt_dictionary(model)
+    if target_lang in pd:
+        return target_lang
+    if len(target_lang) == 2:
+        for k in pd:
+            if k.lower().startswith(target_lang.lower() + "-"):
+                return k
+    return "auto"
+
+
+def resolve_prompt_id(model, target_lang: str) -> int:
+    """Resolve a language string to its integer prompt id (for logging)."""
+    pd = _prompt_dictionary(model)
+    key = resolve_target_lang(model, target_lang)
+    if key in pd:
+        return int(pd[key])
+    return int(pd.get("auto", 101))
+
+
+def split_lang_tag(text: str) -> Tuple[Optional[str], str]:
+    """Pull any <xx-XX> token(s) out of `text` if present.
+
+    NeMo's tokenizer.decode normally strips special tokens, so the tag
+    rarely survives to this stage. We still scan the full string (not
+    just the start) because the model can emit tag tokens at any
+    position — see ARCHITECTURE.md.
+    """
+    if not text:
+        return None, text
+    pat = re.compile(r"<[A-Za-z]{2,4}-[A-Za-z]{2,4}>")
+    m = pat.search(text)
+    if not m:
+        return None, text
+    first = m.group(0)
+    stripped = pat.sub("", text).strip()
+    return first, stripped
+
+
+def transcribe_streaming(
+    model,
+    audio: np.ndarray,
+    sr: int = 16000,
+    target_lang: str = "auto",
+    pad_and_drop_preencoded: bool = False,
+) -> Tuple[Optional[str], str]:
+    """
+    Returns (detected_lang_tag, text_without_tag).
+
+    `detected_lang_tag` is "<en-US>", "<zh-CN>" etc. when the model
+    emits one. Empirically this is rare on short utterances even in
+    `auto` mode — see ARCHITECTURE.md.
+    """
+    if sr != 16000:
+        raise ValueError(f"expected 16 kHz audio, got {sr}")
+
+    model.encoder.setup_streaming_params()
+
+    # `conformer_stream_step` takes NO prompt kwarg — it reads
+    # `self._inference_prompt_index` set by `set_inference_prompt`, then
+    # `_apply_prompt_to_encoded` runs `prompt_kernel` on the (B, D, T)
+    # encoder output per chunk.
+    resolved_lang = resolve_target_lang(model, target_lang)
+    model.set_inference_prompt(resolved_lang)
+
+    streaming_buffer = CacheAwareStreamingAudioBuffer(
+        model=model,
+        pad_and_drop_preencoded=pad_and_drop_preencoded,
+    )
+    streaming_buffer.reset_buffer()
+    streaming_buffer.append_audio(audio)
+
+    cache_last_channel, cache_last_time, cache_last_channel_len = \
+        model.encoder.get_initial_cache_state(batch_size=1)
+
+    previous_hypotheses = None
+    pred_out_stream = None
+    final_text = ""
+
+    with torch.inference_mode():
+        for step_num, (chunk_audio, chunk_lengths) in enumerate(streaming_buffer):
+            (
+                pred_out_stream,
+                transcribed_texts,
+                cache_last_channel,
+                cache_last_time,
+                cache_last_channel_len,
+                previous_hypotheses,
+            ) = model.conformer_stream_step(
+                processed_signal=chunk_audio,
+                processed_signal_length=chunk_lengths,
+                cache_last_channel=cache_last_channel,
+                cache_last_time=cache_last_time,
+                cache_last_channel_len=cache_last_channel_len,
+                keep_all_outputs=streaming_buffer.is_buffer_empty(),
+                previous_hypotheses=previous_hypotheses,
+                previous_pred_out=pred_out_stream,
+                drop_extra_pre_encoded=calc_drop_extra_pre_encoded(
+                    model, step_num, pad_and_drop_preencoded
+                ),
+                return_transcription=True,
+            )
+
+            if transcribed_texts and len(transcribed_texts) > 0:
+                t = transcribed_texts[0]
+                final_text = t.text if hasattr(t, "text") else str(t)
+
+    return split_lang_tag(final_text)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="NeMo Multilingual Reference")
+    parser.add_argument("--audio", type=str, required=True, help="Path to audio file (16 kHz mono).")
+    parser.add_argument(
+        "--target-lang",
+        type=str,
+        default="auto",
+        help='Language code, e.g. "en-US", "zh-CN", or "auto" (default).',
+    )
+    parser.add_argument("--duration", type=float, default=None, help="Trim audio to N seconds.")
+    parser.add_argument(
+        "--nemo-path",
+        type=str,
+        default=None,
+        help="Local .nemo path; if omitted, downloads via from_pretrained().",
+    )
+    parser.add_argument(
+        "--pad-and-drop",
+        action="store_true",
+        help="Match CoreML/ONNX export behavior (pad_and_drop_preencoded=True).",
+    )
+    args = parser.parse_args()
+
+    audio, sr = sf.read(args.audio, dtype="float32")
+    if audio.ndim > 1:
+        audio = audio.mean(axis=1)
+    if args.duration:
+        audio = audio[: int(args.duration * sr)]
+
+    print("=" * 70)
+    print("NEMOTRON MULTILINGUAL STREAMING (NeMo reference)")
+    print("=" * 70)
+    print(f"Audio:      {len(audio)/sr:.2f}s @ {sr}Hz")
+    print(f"target_lang: {args.target_lang}")
+
+    print("\nLoading model...")
+    if args.nemo_path:
+        model = nemo_asr.models.ASRModel.restore_from(args.nemo_path)
+    else:
+        model = nemo_asr.models.ASRModel.from_pretrained(DEFAULT_MODEL_ID)
+    model.eval()
+
+    pd = _prompt_dictionary(model)
+    resolved = resolve_target_lang(model, args.target_lang)
+    prompt_id = resolve_prompt_id(model, args.target_lang)
+    print(f"resolved_lang: {resolved}")
+    print(f"prompt_id:     {prompt_id} (auto={pd.get('auto', '?')})")
+
+    print(f"\n[STREAMING] 1.12s chunks, pad_and_drop={args.pad_and_drop}")
+    detected, text = transcribe_streaming(
+        model,
+        audio,
+        sr=sr,
+        target_lang=args.target_lang,
+        pad_and_drop_preencoded=args.pad_and_drop,
+    )
+    print(f"  detected_lang: {detected}")
+    print(f"  text:          {text}")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/pyproject.toml
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "nemotron-multilingual-openvino"
+version = "0.1.0"
+description = "OpenVINO IR export + INT8 quantization + FLEURS benchmark for Nemotron Multilingual Streaming 0.6B (CPU/NPU)"
+requires-python = ">=3.10,<3.11"
+dependencies = [
+    "openvino>=2026.2.0",   # IR convert/compile/runtime (CPU; NPU on supported HW)
+    "nncf>=2.12.0",         # weight-only INT8 compression (quantize_int8_wo.py)
+    "soundfile>=0.12.0",
+    "numpy>=1.24.0",
+    "typer>=0.12.0",
+    "datasets>=2.18.0",     # google/fleurs streaming (benchmark_fleurs_ov.py)
+    "scipy>=1.11.0",        # resampling FLEURS audio to 16 kHz
+]
+
+# export_openvino.py traces the *same* backend-agnostic TorchScript wrappers as
+# the CoreML pipeline (imported from ../coreml/conversion_scripts via sys.path),
+# so exporting also needs NeMo + torch in the environment:
+#   uv pip install "nemo_toolkit[asr]" torch
+# Pure OV inference / quantization / benchmarking does not need NeMo.
+
+[tool.uv]
+dev-dependencies = []

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/quantize_int8.py
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/quantize_int8.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+"""INT8 PTQ of the Nemotron streaming encoder via NNCF.
+
+- Captures REAL encoder input dicts (incl. evolved cache tensors + per-lang
+  prompt_id) by running the FP32 streaming pipeline over a small multilingual
+  calibration set streamed from FLEURS (no full-config download).
+- Quantizes only the encoder (the ~1.25GB bulk) with model_type=TRANSFORMER
+  (keeps attention softmax in higher precision). Decoder/joint/preprocessor
+  stay FP16.
+- Writes build_ov_int8/ = int8 encoder + fp16 {decoder,joint,preprocessor}
+  + vocab + metadata.
+"""
+import os, sys, shutil, itertools, json
+from pathlib import Path
+import numpy as np
+import openvino as ov
+import nncf
+from transcribe_ov import NemotronOV
+
+SRC_FP32 = Path("build_ov")          # quantize encoder from FP32 source
+SRC_FP16 = Path("build_ov_fp16")     # reuse fp16 for the rest
+OUT      = Path("build_ov_int8")
+OUT.mkdir(exist_ok=True)
+
+# (fleurs config, nemo lang tag) — diverse scripts/prompt_ids
+CALIB = [("en_us","en-US"), ("es_419","es-ES"), ("fr_fr","fr-FR"),
+         ("cmn_hans_cn","zh-CN"), ("ja_jp","ja-JP")]
+FILES_PER_LANG = 6
+SUBSET = 400   # encoder-call samples used by NNCF
+
+def capture_samples():
+    import io
+    import soundfile as sf
+    from datasets import load_dataset, Audio
+    model = NemotronOV(str(SRC_FP32), device="CPU")
+    samples = []
+    orig_enc = model.encoder
+    def recorder(d):
+        samples.append({k: np.array(v, copy=True) for k, v in d.items()})
+        return orig_enc(d)
+    model.encoder = recorder
+    for cfg, lang in CALIB:
+        print(f"[calib] streaming {cfg} ({lang}) ...", flush=True)
+        # Audio(decode=False)+soundfile: datasets 5.0 default decode needs torchcodec
+        ds = load_dataset("google/fleurs", cfg, split="validation",
+                          streaming=True, token=os.environ.get("HF_TOKEN"))
+        ds = ds.cast_column("audio", Audio(decode=False))
+        n = 0
+        for ex in itertools.islice(ds, FILES_PER_LANG):
+            audio, sr = sf.read(io.BytesIO(ex["audio"]["bytes"]), dtype="float32")
+            if audio.ndim > 1:
+                audio = audio.mean(axis=1)
+            model.transcribe_streaming(np.asarray(audio, dtype=np.float32), target_lang=lang)
+            n += 1
+        print(f"[calib]   {cfg}: {n} files, total enc-calls so far={len(samples)}", flush=True)
+    print(f"[calib] captured {len(samples)} encoder-input samples", flush=True)
+    return samples
+
+def main():
+    samples = capture_samples()
+    if not samples:
+        print("ERROR: no calibration samples captured"); sys.exit(1)
+    core = ov.Core()
+    enc = core.read_model(str(SRC_FP32 / "nemotron_encoder.xml"))
+    calib = nncf.Dataset(samples, lambda x: x)
+    print(f"[nncf] quantizing encoder (subset={min(SUBSET,len(samples))}) ...", flush=True)
+    q = nncf.quantize(enc, calib, subset_size=min(SUBSET, len(samples)),
+                      model_type=nncf.ModelType.TRANSFORMER)
+    ov.save_model(q, str(OUT / "nemotron_encoder.xml"), compress_to_fp16=True)
+    print("[nncf] encoder int8 saved", flush=True)
+    # rest from fp16
+    for f in ["nemotron_decoder.xml","nemotron_decoder.bin",
+              "nemotron_joint.xml","nemotron_joint.bin",
+              "nemotron_preprocessor.xml","nemotron_preprocessor.bin",
+              "nemotron_vocab.json","metadata.json"]:
+        shutil.copy(SRC_FP16 / f, OUT / f)
+    # mark precision
+    md = json.load(open(OUT / "metadata.json")); md["precision"] = "INT8 (encoder) + FP16"
+    json.dump(md, open(OUT / "metadata.json","w"), indent=2)
+    print("DONE -> build_ov_int8", flush=True)
+
+if __name__ == "__main__":
+    main()

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/quantize_int8_wo.py
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/quantize_int8_wo.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+"""Weight-only INT8 quantization of the Nemotron streaming encoder (OpenVINO).
+
+Mirrors the mobius CoreML approach (`linear_quantize_weights`, per-channel
+linear-symmetric, encoder only): only the weight consts become int8 with
+per-output-channel fp16 scales; activations stay fp16. This is DATA-FREE
+(no calibration) and far less aggressive than full PTQ (nncf.quantize),
+which also quantizes activations and cost us ~+7 WER on English.
+
+NNCF equivalent: compress_weights(mode=INT8_SYM) — per-channel symmetric
+int8 weight compression. Decoder/joint/preprocessor copied from FP16.
+
+Output: build_ov_int8/ = int8-weight encoder + fp16 {decoder,joint,preproc}.
+"""
+import json, shutil
+from pathlib import Path
+import openvino as ov
+import nncf
+
+SRC_FP32 = Path("build_ov")        # quantize encoder weights from FP32 master
+SRC_FP16 = Path("build_ov_fp16")   # reuse fp16 for the rest
+OUT      = Path("build_ov_int8")
+OUT.mkdir(exist_ok=True)
+
+def main():
+    core = ov.Core()
+    enc = core.read_model(str(SRC_FP32 / "nemotron_encoder.xml"))
+    print("[nncf] compress_weights INT8_SYM (per-channel, weight-only) ...", flush=True)
+    q = nncf.compress_weights(enc, mode=nncf.CompressWeightsMode.INT8_SYM)
+    ov.save_model(q, str(OUT / "nemotron_encoder.xml"), compress_to_fp16=True)
+    print("[nncf] encoder int8-weight saved", flush=True)
+
+    for f in ["nemotron_decoder.xml", "nemotron_decoder.bin",
+              "nemotron_joint.xml", "nemotron_joint.bin",
+              "nemotron_preprocessor.xml", "nemotron_preprocessor.bin",
+              "nemotron_vocab.json", "metadata.json"]:
+        shutil.copy(SRC_FP16 / f, OUT / f)
+
+    md = json.load(open(OUT / "metadata.json"))
+    md["precision"] = "INT8 weight-only (encoder) + FP16"
+    json.dump(md, open(OUT / "metadata.json", "w"), indent=2)
+    print("DONE -> build_ov_int8", flush=True)
+
+if __name__ == "__main__":
+    main()

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/rss_probe.py
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/rss_probe.py
@@ -1,0 +1,9 @@
+import sys, resource, numpy as np, soundfile as sf
+from transcribe_ov import NemotronOV
+d=sys.argv[1]
+m=NemotronOV(d, device="CPU")
+a,sr=sf.read("sample.wav",dtype="float32")
+if a.ndim>1: a=a.mean(1)
+_=m.transcribe_streaming(np.asarray(a,dtype=np.float32), target_lang="auto")
+peak=resource.getrusage(resource.RUSAGE_SELF).ru_maxrss/1024
+print(f"{d}: peak RSS {peak:.0f} MB")

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/run_fleurs_int8.sh
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/run_fleurs_int8.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -u
+cd ~/nemotron-ov-export
+source .venv/bin/activate
+# Set HF_TOKEN in your environment before running (do not hardcode tokens):
+#   export HF_TOKEN=hf_xxx
+: "${HF_TOKEN:?set HF_TOKEN to your Hugging Face access token}"
+clear_cache() {
+  rm -rf ~/.cache/huggingface/datasets/google___fleurs* \
+         ~/.cache/huggingface/hub/datasets--google--fleurs* 2>/dev/null
+}
+run_lang() {
+  local L="$1"
+  for attempt in 1 2; do
+    echo "########## $L (attempt $attempt) ##########"
+    python benchmark_fleurs_ov.py \
+      --model-dir ./build_ov_int8 --languages "$L" --mode forced --use-hf \
+      --output-json "int8_full_${L}.json" > "int8_${L}.log" 2>&1
+    if [ -f "int8_full_${L}.json" ]; then
+      echo "[$L OK]"; grep -E "files=|WER=|CER=" "int8_${L}.log" | tail -1
+      clear_cache; return 0
+    fi
+    echo "[$L attempt $attempt failed]"; tail -3 "int8_${L}.log"
+    clear_cache
+  done
+  echo "[$L GAVE UP]"; return 1
+}
+for L in en_us es_419 fr_fr cmn_hans_cn ja_jp; do run_lang "$L"; done
+echo "ALL DONE"

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/run_fleurs_int8wo.sh
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/run_fleurs_int8wo.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -u
+cd ~/nemotron-ov-export
+source .venv/bin/activate
+# Set HF_TOKEN in your environment before running (do not hardcode tokens):
+#   export HF_TOKEN=hf_xxx
+: "${HF_TOKEN:?set HF_TOKEN to your Hugging Face access token}"
+clear_cache(){ rm -rf ~/.cache/huggingface/datasets/google___fleurs* ~/.cache/huggingface/hub/datasets--google--fleurs* 2>/dev/null; }
+for L in en_us es_419 fr_fr cmn_hans_cn ja_jp; do
+  for attempt in 1 2; do
+    echo "##### $L (attempt $attempt) #####"
+    python benchmark_fleurs_ov.py --model-dir ./build_ov_int8 --languages "$L" --mode forced --use-hf \
+      --output-json "int8wo_full_${L}.json" > "int8wo_${L}.log" 2>&1
+    [ -f "int8wo_full_${L}.json" ] && { echo "[$L OK]"; clear_cache; break; }
+    echo "[$L attempt $attempt failed]"; tail -3 "int8wo_${L}.log"; clear_cache
+  done
+done
+echo "ALL DONE"

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/run_fleurs_rest.sh
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/run_fleurs_rest.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -u
+cd ~/nemotron-ov-export
+source .venv/bin/activate
+clear_cache() {
+  rm -rf ~/.cache/huggingface/datasets/google___fleurs* \
+         ~/.cache/huggingface/hub/datasets--google--fleurs* 2>/dev/null
+}
+run_lang() {
+  local L="$1"
+  for attempt in 1 2; do
+    echo "########## $L (attempt $attempt) ##########"
+    python benchmark_fleurs_ov.py \
+      --model-dir ./build_ov --languages "$L" --mode forced --use-hf \
+      --output-json "ov_full_${L}.json" > "full_${L}.log" 2>&1
+    if [ -f "ov_full_${L}.json" ]; then
+      echo "[$L OK]"; grep -E "files=|WER=|CER=" "full_${L}.log" | tail -1
+      clear_cache; return 0
+    fi
+    echo "[$L attempt $attempt failed]"; tail -3 "full_${L}.log"
+    clear_cache
+  done
+  echo "[$L GAVE UP]"; return 1
+}
+for L in fr_fr cmn_hans_cn ja_jp; do run_lang "$L"; done
+echo "ALL DONE"

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/run_fleurs_seq.sh
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/run_fleurs_seq.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Serialized full FLEURS forced-mode eval over 5 languages on the FP32 OV
+# export. ONE process at a time (4 cores). Retry each language once on
+# transient HF download failure. Clear that language's cache afterward to
+# bound disk. en config may already be cached (runs first, no pre-clear).
+set -u
+cd ~/nemotron-ov-export
+source .venv/bin/activate
+
+clear_cache() {
+  rm -rf ~/.cache/huggingface/datasets/google___fleurs* \
+         ~/.cache/huggingface/hub/datasets--google--fleurs* 2>/dev/null
+}
+
+run_lang() {
+  local L="$1"
+  for attempt in 1 2; do
+    echo "########## $L (attempt $attempt) ##########"
+    python benchmark_fleurs_ov.py \
+      --model-dir ./build_ov --languages "$L" --mode forced --use-hf \
+      --output-json "ov_full_${L}.json" > "full_${L}.log" 2>&1
+    if [ -f "ov_full_${L}.json" ]; then
+      echo "[$L OK]"; grep -E "files=|WER=|CER=" "full_${L}.log" | tail -1
+      return 0
+    fi
+    echo "[$L attempt $attempt failed; tail:]"; tail -3 "full_${L}.log"
+    clear_cache
+  done
+  echo "[$L GAVE UP]"
+  return 1
+}
+
+for L in en_us es_419 fr_fr cmn_hans_cn ja_jp; do
+  run_lang "$L"
+  clear_cache
+done
+echo "ALL DONE"

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/run_full_fleurs.sh
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/run_full_fleurs.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Full FLEURS forced-mode WER/CER across 5 languages on the FP32 OV export.
+# Runs sequentially (4 cores) and clears each language's HF cache afterward
+# to keep disk bounded (~13G peak per language).
+set -u
+cd ~/nemotron-ov-export
+source .venv/bin/activate
+
+LANGS="en_us es_419 fr_fr cmn_hans_cn ja_jp"
+for L in $LANGS; do
+  echo "########## $L ##########"
+  python benchmark_fleurs_ov.py \
+    --model-dir ./build_ov \
+    --languages "$L" \
+    --mode forced \
+    --use-hf \
+    --output-json "ov_full_${L}.json" 2>&1 \
+    | grep -vE "OneLogger|telemetry|Downloading|Generating|Resolving|^\s*$|unauthenticated|HF_TOKEN"
+  # Reclaim disk before next language
+  rm -rf ~/.cache/huggingface/datasets/google___fleurs* \
+         ~/.cache/huggingface/hub/datasets--google--fleurs* 2>/dev/null
+  echo "[cache cleared for $L]"
+done
+echo "ALL DONE"

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/transcribe_ov.py
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/transcribe_ov.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Streaming OpenVINO inference for Nemotron-3.5-ASR-Streaming-Multilingual 0.6B.
+
+Direct port of mobius's `test_coreml_multilingual.py` streaming loop, with
+`ct.models.MLModel(...).predict(d)` replaced by OpenVINO
+`core.compile_model(xml, "CPU")` + `compiled(d)`. Same chunking, same cache
+plumbing, same greedy RNNT decode — only the runtime differs. This validates
+that the OpenVINO IR produced by export_openvino.py transcribes correctly.
+"""
+import argparse
+import json
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import numpy as np
+import openvino as ov
+import soundfile as sf
+
+
+class NemotronOV:
+    def __init__(self, model_dir: str, device: str = "CPU"):
+        d = Path(model_dir)
+        self.metadata = json.loads((d / "metadata.json").read_text())
+        self.tokenizer = json.loads((d / "nemotron_vocab.json").read_text())
+
+        core = ov.Core()
+        print(f"Loading OpenVINO IR on {device} ...")
+        self.preprocessor = core.compile_model(str(d / "nemotron_preprocessor.xml"), device)
+        self.encoder = core.compile_model(str(d / "nemotron_encoder.xml"), device)
+        self.decoder = core.compile_model(str(d / "nemotron_decoder.xml"), device)
+        self.joint = core.compile_model(str(d / "nemotron_joint.xml"), device)
+        print("Models loaded.")
+
+        m = self.metadata
+        self.sample_rate = m["sample_rate"]
+        self.chunk_mel_frames = m["chunk_mel_frames"]
+        self.pre_encode_cache = m["pre_encode_cache"]
+        self.total_mel_frames = m["total_mel_frames"]
+        self.blank_idx = m["blank_idx"]
+        self.vocab_size = m["vocab_size"]
+        self.decoder_hidden = m["decoder_hidden"]
+        self.decoder_layers = m["decoder_layers"]
+        self.cache_channel_shape = m["cache_channel_shape"]
+        self.cache_time_shape = m["cache_time_shape"]
+        self.prompt_dictionary = m.get("prompt_dictionary", {})
+        self.lang_tag_token_ids = set(m.get("lang_tag_token_ids", []))
+        self.default_prompt_id = int(m.get("default_prompt_id", 101))
+        self.chunk_samples = int(self.chunk_mel_frames * 0.01 * self.sample_rate)
+
+    def resolve_prompt_id(self, target_lang: str) -> int:
+        if target_lang in self.prompt_dictionary:
+            return int(self.prompt_dictionary[target_lang])
+        if len(target_lang) == 2:
+            for k, v in self.prompt_dictionary.items():
+                if k.lower().startswith(target_lang.lower() + "-"):
+                    return int(v)
+        return self.default_prompt_id
+
+    def piece_for_id(self, t: int) -> str:
+        return self.tokenizer.get(str(t), "")
+
+    def _decode_tokens(self, tokens: List[int]) -> Tuple[Optional[str], str]:
+        detected, body = None, []
+        for tok in tokens:
+            if tok == self.blank_idx or tok >= self.vocab_size:
+                continue
+            if tok in self.lang_tag_token_ids:
+                if detected is None:
+                    detected = self.piece_for_id(tok)
+                continue
+            body.append(tok)
+        text = "".join(self.piece_for_id(t) for t in body).replace("▁", " ").strip()
+        return detected, text
+
+    def transcribe_streaming(self, audio: np.ndarray, target_lang: str = "auto"):
+        audio = audio.astype(np.float32)
+        total = len(audio)
+        prompt_id = self.resolve_prompt_id(target_lang)
+        prompt_in = np.array([prompt_id], dtype=np.int32)
+
+        cache_channel = np.zeros(self.cache_channel_shape, dtype=np.float32)
+        cache_time = np.zeros(self.cache_time_shape, dtype=np.float32)
+        cache_len = np.array([0], dtype=np.int32)
+        h = np.zeros((self.decoder_layers, 1, self.decoder_hidden), dtype=np.float32)
+        c = np.zeros((self.decoder_layers, 1, self.decoder_hidden), dtype=np.float32)
+        last_token = self.blank_idx
+        all_tokens: List[int] = []
+        mel_cache = None
+        off = 0
+
+        while off < total:
+            chunk = audio[off:min(off + self.chunk_samples, total)]
+            if len(chunk) < self.chunk_samples:
+                chunk = np.pad(chunk, (0, self.chunk_samples - len(chunk)))
+            chunk = chunk.reshape(1, -1)
+
+            pre = self.preprocessor({
+                "audio": chunk.astype(np.float32),
+                "audio_length": np.array([chunk.shape[1]], dtype=np.int32),
+            })
+            chunk_mel = pre["mel"]
+
+            if mel_cache is not None:
+                input_mel = np.concatenate([mel_cache, chunk_mel], axis=2)
+            else:
+                input_mel = np.pad(chunk_mel, ((0, 0), (0, 0), (self.pre_encode_cache, 0)))
+            cur = input_mel.shape[2]
+            if cur < self.total_mel_frames:
+                input_mel = np.pad(input_mel, ((0, 0), (0, 0), (0, self.total_mel_frames - cur)))
+            elif cur > self.total_mel_frames:
+                input_mel = input_mel[:, :, : self.total_mel_frames]
+            mel_cache = (chunk_mel[:, :, -self.pre_encode_cache:]
+                         if chunk_mel.shape[2] >= self.pre_encode_cache else chunk_mel)
+
+            enc = self.encoder({
+                "mel": input_mel.astype(np.float32),
+                "mel_length": np.array([self.total_mel_frames], dtype=np.int32),
+                "cache_channel": cache_channel,
+                "cache_time": cache_time,
+                "cache_len": cache_len,
+                "prompt_id": prompt_in,
+            })
+            encoded = enc["encoded"]
+            cache_channel = enc["cache_channel_out"]
+            cache_time = enc["cache_time_out"]
+            cache_len = enc["cache_len_out"]
+
+            for t in range(encoded.shape[2]):
+                enc_step = encoded[:, :, t : t + 1]
+                for _ in range(10):
+                    dec = self.decoder({
+                        "token": np.array([[last_token]], dtype=np.int32),
+                        "token_length": np.array([1], dtype=np.int32),
+                        "h_in": h, "c_in": c,
+                    })
+                    decoder_out = dec["decoder_out"]
+                    jo = self.joint({
+                        "encoder": enc_step.astype(np.float32),
+                        "decoder": decoder_out[:, :, :1].astype(np.float32),
+                    })
+                    logits = jo["logits"]
+                    pred = int(np.argmax(logits[0, 0, 0, :]))
+                    if pred == self.blank_idx:
+                        break
+                    all_tokens.append(pred)
+                    last_token = pred
+                    h = dec["h_out"]
+                    c = dec["c_out"]
+            off += self.chunk_samples
+
+        detected, text = self._decode_tokens(all_tokens)
+        return detected, text, prompt_id
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model-dir", required=True)
+    ap.add_argument("--audio", required=True)
+    ap.add_argument("--target-lang", default="auto")
+    ap.add_argument("--duration", type=float, default=None)
+    ap.add_argument("--device", default="CPU")
+    args = ap.parse_args()
+
+    audio, sr = sf.read(args.audio, dtype="float32")
+    if audio.ndim > 1:
+        audio = audio.mean(axis=1)
+    if sr != 16000:
+        raise SystemExit(f"Audio must be 16 kHz; got {sr}.")
+    if args.duration:
+        audio = audio[: int(args.duration * sr)]
+    print(f"audio: {len(audio)/sr:.2f}s @ {sr}Hz")
+
+    runner = NemotronOV(args.model_dir, device=args.device)
+    detected, text, pid = runner.transcribe_streaming(audio, target_lang=args.target_lang)
+    print("\n--- OpenVINO result ---")
+    print(f"prompt_id_used: {pid}")
+    print(f"detected_lang:  {detected}")
+    print(f"text:           {text}")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/transcribe_ov.py
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/transcribe_ov.py
@@ -20,8 +20,11 @@ import soundfile as sf
 class NemotronOV:
     def __init__(self, model_dir: str, device: str = "CPU"):
         d = Path(model_dir)
-        self.metadata = json.loads((d / "metadata.json").read_text())
-        self.tokenizer = json.loads((d / "nemotron_vocab.json").read_text())
+        # encoding="utf-8": the vocab contains non-ASCII (U+2581, CJK) pieces;
+        # Path.read_text() defaults to the locale codec (cp1252 on Windows) and
+        # raises UnicodeDecodeError otherwise.
+        self.metadata = json.loads((d / "metadata.json").read_text(encoding="utf-8"))
+        self.tokenizer = json.loads((d / "nemotron_vocab.json").read_text(encoding="utf-8"))
 
         core = ov.Core()
         print(f"Loading OpenVINO IR on {device} ...")

--- a/models/stt/nemotron-speech-streaming-0.6b/openvino/export_openvino.py
+++ b/models/stt/nemotron-speech-streaming-0.6b/openvino/export_openvino.py
@@ -281,7 +281,11 @@ def convert(
     # === 5. Vocab + metadata (no prompt fields) ===
     vocab_size = int(model.tokenizer.vocab_size)
     vocab = {str(i): model.tokenizer.ids_to_tokens([i])[0] for i in range(vocab_size)}
-    (output_dir / "nemotron_vocab.json").write_text(json.dumps(vocab, ensure_ascii=False, indent=2))
+    # encoding="utf-8": pieces contain U+2581 / non-ASCII; write_text defaults to
+    # the locale codec (cp1252 on Windows) and would crash.
+    (output_dir / "nemotron_vocab.json").write_text(
+        json.dumps(vocab, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
 
     metadata = {
         "model": model_id,
@@ -300,7 +304,7 @@ def convert(
         "decoder_layers": dec_layers,
         "encoder_dim": int(enc_out.shape[1]),
     }
-    (output_dir / "metadata.json").write_text(json.dumps(metadata, indent=2))
+    (output_dir / "metadata.json").write_text(json.dumps(metadata, indent=2), encoding="utf-8")
     print(f"Done. Exported OpenVINO IR to {output_dir}")
 
 

--- a/models/stt/nemotron-speech-streaming-0.6b/openvino/export_openvino.py
+++ b/models/stt/nemotron-speech-streaming-0.6b/openvino/export_openvino.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Export NVIDIA nemotron-speech-streaming-en-0.6b to OpenVINO IR.
+
+Monolingual (English) sibling of nemotron-3.5-asr-streaming-multilingual-0.6b.
+Same cache-aware streaming FastConformer-RNNT, but with NO prompt/language
+conditioning — so the exported encoder has no `prompt_id` input. Produces the
+same flat IR layout the eddy-audio backend consumes (the eddy backend
+auto-detects the absent prompt_id and serves both variants):
+
+    nemotron_preprocessor.xml/.bin   audio -> mel
+    nemotron_encoder.xml/.bin        mel + caches -> encoded + caches
+    nemotron_decoder.xml/.bin        token + lstm state -> dec_out + state
+    nemotron_joint.xml/.bin          enc_step + dec_step -> logits
+    nemotron_vocab.json, metadata.json
+
+Mirrors ../../nemotron-asr-streaming-multilingual-0.6b/openvino/export_openvino.py.
+Requires NeMo + torch + openvino (no coremltools — wrappers are inlined).
+
+    uv run python export_openvino.py --output-dir build_ov --precision FP16
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Tuple
+
+import openvino as ov
+import openvino.runtime.opset13 as _ovops
+from openvino.runtime.utils import replace_node as _ov_replace_node
+import torch
+import typer
+
+DEFAULT_MODEL_ID = "nvidia/nemotron-speech-streaming-en-0.6b"
+
+
+# --- TorchScript wrappers (inlined from the coreml conversion scripts, minus
+# coremltools, minus the multilingual prompt kernel). ---
+
+class PreprocessorWrapper(torch.nn.Module):
+    def __init__(self, module: torch.nn.Module) -> None:
+        super().__init__()
+        self.module = module
+
+    def forward(self, audio_signal: torch.Tensor, length: torch.Tensor):
+        mel, mel_length = self.module(input_signal=audio_signal, length=length.to(dtype=torch.long))
+        return mel, mel_length
+
+
+class EncoderStreamingWrapper(torch.nn.Module):
+    """Cache-aware streaming encoder: mel + caches -> encoded + caches.
+
+    No prompt_id (monolingual). Caches are [B, L, ...] externally, transposed to
+    [L, B, ...] for NeMo and back on output, matching the multilingual export so
+    eddy's cache-carry logic is identical.
+    """
+
+    def __init__(self, module: torch.nn.Module) -> None:
+        super().__init__()
+        self.module = module
+
+    def forward(
+        self,
+        features: torch.Tensor,
+        length: torch.Tensor,
+        cache_last_channel: torch.Tensor,
+        cache_last_time: torch.Tensor,
+        cache_last_channel_len: torch.Tensor,
+    ):
+        cache_ch_t = cache_last_channel.transpose(0, 1)
+        cache_t_t = cache_last_time.transpose(0, 1)
+        cache_len_i64 = cache_last_channel_len.to(dtype=torch.int64)
+        encoded, encoded_lengths, cache_ch_next, cache_t_next, cache_len_next = self.module(
+            audio_signal=features,
+            length=length.to(dtype=torch.long),
+            cache_last_channel=cache_ch_t,
+            cache_last_time=cache_t_t,
+            cache_last_channel_len=cache_len_i64,
+        )
+        return (
+            encoded,
+            encoded_lengths.to(dtype=torch.int32),
+            cache_ch_next.transpose(0, 1),
+            cache_t_next.transpose(0, 1),
+            cache_len_next.to(dtype=torch.int32),
+        )
+
+
+class DecoderWrapper(torch.nn.Module):
+    def __init__(self, module: torch.nn.Module) -> None:
+        super().__init__()
+        self.module = module
+
+    def forward(self, targets, target_lengths, h_in, c_in):
+        decoder_output, _, new_state = self.module(
+            targets=targets.to(dtype=torch.long),
+            target_length=target_lengths.to(dtype=torch.long),
+            states=[h_in, c_in],
+        )
+        return decoder_output, new_state[0], new_state[1]
+
+
+class JointWrapper(torch.nn.Module):
+    def __init__(self, module: torch.nn.Module) -> None:
+        super().__init__()
+        self.module = module
+
+    def forward(self, encoder_outputs, decoder_outputs):
+        encoder_outputs = encoder_outputs.transpose(1, 2)  # [B, T, D]
+        decoder_outputs = decoder_outputs.transpose(1, 2)  # [B, U, D]
+        enc_proj = self.module.enc(encoder_outputs)
+        dec_proj = self.module.pred(decoder_outputs)
+        x = enc_proj.unsqueeze(2) + dec_proj.unsqueeze(1)
+        x = self.module.joint_net[0](x)  # ReLU
+        x = self.module.joint_net[1](x)  # Dropout (no-op in eval)
+        return self.module.joint_net[2](x)  # Linear -> logits
+
+
+def _shape(t: torch.Tensor) -> Tuple[int, ...]:
+    return tuple(int(d) for d in t.shape)
+
+
+def _make_npu_safe(ov_model: ov.Model) -> int:
+    """Rewrite BitwiseNot(bool) -> LogicalNot so the IR runs on the OpenVINO NPU.
+
+    The NPU plugin does an integer complement on a boolean (~0=-1, ~1=-2 are both
+    'true'), so the FastConformer attention mask goes all-true -> uniform softmax
+    -> the encoder output collapses to ~0 -> empty transcripts. LogicalNot is
+    identical on bool and compiles correctly on NPU (no-op for CPU/GPU).
+    """
+    n = 0
+    for op in list(ov_model.get_ordered_ops()):
+        if op.get_type_name() == "BitwiseNot":
+            repl = _ovops.logical_not(op.input_value(0))
+            repl.get_output_tensor(0).set_names(op.get_output_tensor(0).get_names())
+            _ov_replace_node(op, repl)
+            n += 1
+    return n
+
+
+def _save_ir(traced, example_input, input_specs, output_names, out_path: Path, fp16: bool) -> None:
+    ov_model = ov.convert_model(
+        traced, example_input=example_input, input=[(s[1], s[2]) for s in input_specs]
+    )
+    for port, (name, _, _) in zip(ov_model.inputs, input_specs):
+        port.get_tensor().set_names({name})
+    for port, name in zip(ov_model.outputs, output_names):
+        port.get_tensor().set_names({name})
+    n_fixed = _make_npu_safe(ov_model)
+    if n_fixed:
+        print(f"  NPU-safe: rewrote {n_fixed} BitwiseNot -> LogicalNot")
+    ov_model.validate_nodes_and_infer_types()
+    ov.save_model(ov_model, str(out_path), compress_to_fp16=fp16)
+    print(f"  saved {out_path.name}")
+
+
+app = typer.Typer(add_completion=False, pretty_exceptions_show_locals=False)
+
+
+@app.command()
+def convert(
+    model_id: str = typer.Option(DEFAULT_MODEL_ID, "--model-id"),
+    nemo_path: str = typer.Option("", "--nemo-path", help="Local .nemo (overrides --model-id)"),
+    output_dir: Path = typer.Option(Path("build_ov"), "--output-dir"),
+    precision: str = typer.Option("FP32", "--precision", help="FP32 or FP16"),
+) -> None:
+    import nemo.collections.asr as nemo_asr
+
+    fp16 = precision.upper() == "FP16"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if nemo_path:
+        print(f"Loading model from {nemo_path} ...")
+        model = nemo_asr.models.ASRModel.restore_from(restore_path=nemo_path, map_location="cpu")
+    else:
+        print(f"Loading model {model_id} ...")
+        model = nemo_asr.models.EncDecRNNTBPEModel.from_pretrained(model_id, map_location="cpu")
+    model.eval()
+    model_class = f"{type(model).__module__}.{type(model).__name__}"
+    print(f"  class: {model_class}")
+
+    sample_rate = int(model.cfg.preprocessor.sample_rate)
+    mel_features = int(model.cfg.preprocessor.features)
+
+    encoder = model.encoder
+    encoder.setup_streaming_params()
+    # Streaming chunk geometry from the model config (chunk_size=[105,112],
+    # pre_encode_cache_size=[0,9] for this checkpoint -> 112 + 9 = 121).
+    chunk_mel_frames = int(encoder.streaming_cfg.chunk_size[-1])
+    pre_encode_cache = int(encoder.streaming_cfg.pre_encode_cache_size[-1])
+    total_mel_frames = chunk_mel_frames + pre_encode_cache
+
+    cache_channel, cache_time, cache_len = encoder.get_initial_cache_state(batch_size=1, device="cpu")
+    cache_len = cache_len.to(torch.int32)
+    cache_channel_b = cache_channel.transpose(0, 1)
+    cache_time_b = cache_time.transpose(0, 1)
+    print(f"  chunk={chunk_mel_frames} pre_cache={pre_encode_cache} total={total_mel_frames}")
+    print(f"  caches: channel={_shape(cache_channel_b)} time={_shape(cache_time_b)}")
+
+    encoder_streaming = EncoderStreamingWrapper(encoder.eval())
+    preprocessor = PreprocessorWrapper(model.preprocessor.eval())
+    decoder = DecoderWrapper(model.decoder.eval())
+    joint = JointWrapper(model.joint.eval())
+    model.decoder._rnnt_export = True
+
+    max_samples = int(30.0 * sample_rate)
+
+    # === 1. Preprocessor (dynamic audio length) ===
+    print("Exporting preprocessor ...")
+    audio = torch.randn(1, max_samples)
+    pp_ex = (audio, torch.tensor([max_samples], dtype=torch.int32))
+    traced = torch.jit.trace(preprocessor, pp_ex, strict=False)
+    _save_ir(
+        traced, pp_ex,
+        [("audio", [1, -1], ov.Type.f32), ("audio_length", [1], ov.Type.i32)],
+        ["mel", "mel_length"],
+        output_dir / "nemotron_preprocessor.xml", fp16,
+    )
+
+    # === 2. Encoder (cache-aware streaming, NO prompt_id) ===
+    print("Exporting encoder ...")
+    mel = torch.randn(1, mel_features, total_mel_frames)
+    mel_len = torch.tensor([total_mel_frames], dtype=torch.int32)
+    enc_ex = (mel, mel_len, cache_channel_b, cache_time_b, cache_len)
+    traced = torch.jit.trace(encoder_streaming, enc_ex, strict=False)
+    _save_ir(
+        traced, enc_ex,
+        [
+            ("mel", list(_shape(mel)), ov.Type.f32),
+            ("mel_length", [1], ov.Type.i32),
+            ("cache_channel", list(_shape(cache_channel_b)), ov.Type.f32),
+            ("cache_time", list(_shape(cache_time_b)), ov.Type.f32),
+            ("cache_len", [1], ov.Type.i32),
+        ],
+        ["encoded", "encoded_length", "cache_channel_out", "cache_time_out", "cache_len_out"],
+        output_dir / "nemotron_encoder.xml", fp16,
+    )
+
+    # === 3. Decoder (RNNT prediction, single step) ===
+    print("Exporting decoder ...")
+    dec_hidden = int(model.decoder.pred_hidden)
+    dec_layers = int(model.decoder.pred_rnn_layers)
+    targets = torch.tensor([[model.decoder.blank_idx]], dtype=torch.int32)
+    target_len = torch.tensor([1], dtype=torch.int32)
+    h = torch.zeros(dec_layers, 1, dec_hidden)
+    c = torch.zeros(dec_layers, 1, dec_hidden)
+    dec_ex = (targets, target_len, h, c)
+    traced = torch.jit.trace(decoder, dec_ex, strict=False)
+    _save_ir(
+        traced, dec_ex,
+        [
+            ("token", [1, 1], ov.Type.i32),
+            ("token_length", [1], ov.Type.i32),
+            ("h_in", list(_shape(h)), ov.Type.f32),
+            ("c_in", list(_shape(c)), ov.Type.f32),
+        ],
+        ["decoder_out", "h_out", "c_out"],
+        output_dir / "nemotron_decoder.xml", fp16,
+    )
+
+    # === 4. Joint (single step) ===
+    print("Exporting joint ...")
+    with torch.no_grad():
+        mel_test, _ = preprocessor(audio[:, :sample_rate], torch.tensor([sample_rate], dtype=torch.int32))
+        cc, ct_, cl = encoder.get_initial_cache_state(batch_size=1, device="cpu")
+        enc_out, _, _, _, _ = encoder_streaming(
+            mel_test, torch.tensor([mel_test.shape[2]], dtype=torch.int32),
+            cc.transpose(0, 1), ct_.transpose(0, 1), cl.to(torch.int32),
+        )
+        dec_out, _, _ = decoder(targets, target_len, h, c)
+    enc_step = enc_out[:, :, :1].contiguous()
+    dec_step = dec_out[:, :, :1].contiguous()
+    joint_ex = (enc_step, dec_step)
+    traced = torch.jit.trace(joint, joint_ex, strict=False)
+    _save_ir(
+        traced, joint_ex,
+        [("encoder", list(_shape(enc_step)), ov.Type.f32), ("decoder", list(_shape(dec_step)), ov.Type.f32)],
+        ["logits"],
+        output_dir / "nemotron_joint.xml", fp16,
+    )
+
+    # === 5. Vocab + metadata (no prompt fields) ===
+    vocab_size = int(model.tokenizer.vocab_size)
+    vocab = {str(i): model.tokenizer.ids_to_tokens([i])[0] for i in range(vocab_size)}
+    (output_dir / "nemotron_vocab.json").write_text(json.dumps(vocab, ensure_ascii=False, indent=2))
+
+    metadata = {
+        "model": model_id,
+        "model_class": model_class,
+        "precision": precision.upper(),
+        "sample_rate": sample_rate,
+        "mel_features": mel_features,
+        "chunk_mel_frames": chunk_mel_frames,
+        "pre_encode_cache": pre_encode_cache,
+        "total_mel_frames": total_mel_frames,
+        "vocab_size": vocab_size,
+        "blank_idx": int(model.decoder.blank_idx),
+        "cache_channel_shape": list(cache_channel_b.shape),
+        "cache_time_shape": list(cache_time_b.shape),
+        "decoder_hidden": dec_hidden,
+        "decoder_layers": dec_layers,
+        "encoder_dim": int(enc_out.shape[1]),
+    }
+    (output_dir / "metadata.json").write_text(json.dumps(metadata, indent=2))
+    print(f"Done. Exported OpenVINO IR to {output_dir}")
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
OpenVINO analogue of the CoreML conversion pipeline for **Nemotron-3.5-ASR-Streaming-Multilingual 0.6B**, targeting CPU/NPU. Reuses the *exact same* backend-agnostic TorchScript wrappers as the CoreML path (imported from `../coreml/conversion_scripts`), swapping `ct.convert` for `ov.convert_model`.

New dir: `models/stt/nemotron-asr-streaming-multilingual-0.6b/openvino/`

## Contents
- **`export_openvino.py`** — `.nemo` → 4 IR pairs (preprocessor/encoder/decoder/joint) + `vocab.json` + `metadata.json`, the set eddy-audio consumes
- **`quantize_int8.py` / `quantize_int8_wo.py`** — full and weight-only INT8 (NNCF); weight-only excludes the 24 `self_attn.linear_pos` matmuls (OV CPU compile bug)
- **`transcribe_ov.py`** — cache-aware streaming greedy RNNT inference driver
- **`benchmark_fleurs_ov.py` / `bench_ov.py`** — FLEURS WER + RTFx
- **`nemo_reference.py`** — NeMo PyTorch reference for parity
- **`find_offenders.py` / `rss_probe.py`** — `linear_pos` exclusion + RAM probing helpers
- **`bench_results/`** — FLEURS JSON for FP32 and INT8-weight-only across en/es/fr/zh/ja

## Notes
- IR binaries (`build_ov*/`, `*.xml/.bin`, `*.nemo`) are gitignored — regenerate via `export_openvino.py` or download from HuggingFace.
- `export_openvino.py` imports the CoreML wrappers from the sibling `coreml/conversion_scripts/` (via `~/mobius` path), so the export depends on NeMo + torch in the env; pure OV inference/quantization/benchmark does not.
- These IR artifacts are what FluidInference/eddy-audio PR #10 consumes.