### PR TITLE
fix(kokoro): rank-stable vocoder anchor for macOS 14 Espresso

### DIFF
--- a/models/tts/kokoro-v1.1-zh/coreml/scripts/convert-coreml.py
+++ b/models/tts/kokoro-v1.1-zh/coreml/scripts/convert-coreml.py
@@ -102,7 +102,11 @@ class CoreMLVocoderDualOutput(nn.Module):
                     xs = xs + self.resblocks[i * self.num_kernels + j](x, s)
             x = xs / self.num_kernels
         x_pre = F.leaky_relu(x)
-        anchor = x_pre.mean().unsqueeze(0)
+        # Reduce over explicit dims so the MIL keeps rank >= 1 throughout.
+        # mean() -> rank-0 -> unsqueeze lowers to a chain macOS 14's Espresso
+        # runtime mangles into rank 2 ("Output rank has changed after
+        # reshaping"), failing every prediction (FluidAudio#836).
+        anchor = x_pre.mean(dim=(1, 2))
         return anchor, x_pre
 
 

--- a/models/tts/kokoro/laishere-coreml/convert-coreml.py
+++ b/models/tts/kokoro/laishere-coreml/convert-coreml.py
@@ -97,7 +97,11 @@ class CoreMLVocoderDualOutput(nn.Module):
                     xs = xs + self.resblocks[i * self.num_kernels + j](x, s)
             x = xs / self.num_kernels
         x_pre = F.leaky_relu(x)
-        anchor = x_pre.mean().unsqueeze(0)
+        # Reduce over explicit dims so the MIL keeps rank >= 1 throughout.
+        # mean() -> rank-0 -> unsqueeze lowers to a chain macOS 14's Espresso
+        # runtime mangles into rank 2 ("Output rank has changed after
+        # reshaping"), failing every prediction (FluidAudio#836).
+        anchor = x_pre.mean(dim=(1, 2))
         return anchor, x_pre
 
 

--- a/models/tts/kokoro/laishere-coreml/patch-anchor-rank.py
+++ b/models/tts/kokoro/laishere-coreml/patch-anchor-rank.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Rewrite KokoroVocoder's `anchor` output chain to be rank-stable.
+
+Usage: python patch-anchor-rank.py <src.mlpackage> <dst.mlpackage>
+
+Before:  reduce_mean(x_pre, keep_dims=false) -> rank-0
+         expand_dims(axes=[0])               -> [1]  (= anchor)
+After:   reduce_mean(x_pre, axes=[1,2], keep_dims=false) -> [1]  (= anchor)
+
+macOS 14's Espresso runtime mishandles the rank-0 intermediate
+("Output rank has changed after reshaping espresso network ...
+blob = anchor"), producing rank 2 and failing output validation
+(issue FluidInference/FluidAudio#836). The value of `anchor` is
+discarded by all hosts, and `x_pre` is untouched by this patch
+(verified bit-exact on the en and zh vocoders).
+
+`convert-coreml.py` now emits the rank-stable form natively
+(`x_pre.mean(dim=(1, 2))`); this script retrofits already-published
+mlpackages (ANE / ANE-zh; ANE-ja's vocoder is byte-identical to
+ANE's) without re-running conversion and palettization. Recompile to
+mlmodelc afterwards via `MLModel.get_compiled_model_path()` or
+`coremlcompiler compile`.
+"""
+import sys
+
+import coremltools as ct
+from coremltools.proto import MIL_pb2
+
+src, dst = sys.argv[1], sys.argv[2]
+
+spec = ct.utils.load_spec(src)
+prog = spec.mlProgram
+fn = prog.functions["main"]
+block = fn.block_specializations[fn.opset]
+ops = block.operations
+
+# Locate expand_dims producing `anchor`, its reduce_mean input, and the
+# const feeding expand_dims' axes.
+expand_idx = None
+for i, op in enumerate(ops):
+    if op.type == "expand_dims" and any(o.name == "anchor" for o in op.outputs):
+        expand_idx = i
+        break
+assert expand_idx is not None, "expand_dims -> anchor not found"
+expand_op = ops[expand_idx]
+
+reduce_name = expand_op.inputs["x"].arguments[0].name
+axes_const_name = expand_op.inputs["axes"].arguments[0].name
+
+reduce_idx = axes_const_idx = None
+for i, op in enumerate(ops):
+    if any(o.name == reduce_name for o in op.outputs):
+        reduce_idx = i
+    if op.type == "const" and any(o.name == axes_const_name for o in op.outputs):
+        axes_const_idx = i
+assert reduce_idx is not None, "reduce_mean not found"
+reduce_op = ops[reduce_idx]
+assert reduce_op.type == "reduce_mean", reduce_op.type
+assert "axes" not in reduce_op.inputs, "reduce_mean already has axes"
+
+# Repurpose the old expand_dims axes const as the reduce axes [1, 2].
+assert axes_const_idx is not None, "axes const not found"
+axes_const = ops[axes_const_idx]
+val = axes_const.attributes["val"]
+assert val.type.tensorType.dataType == MIL_pb2.DataType.INT32
+val.type.tensorType.dimensions[0].constant.size = 2
+del val.immediateValue.tensor.ints.values[:]
+val.immediateValue.tensor.ints.values.extend([1, 2])
+axes_const.outputs[0].type.tensorType.dimensions[0].constant.size = 2
+
+# reduce_mean: add axes input, rename output to `anchor`, type fp16 [1].
+arg = reduce_op.inputs["axes"].arguments.add()
+arg.name = axes_const_name
+out = reduce_op.outputs[0]
+out.name = "anchor"
+tt = out.type.tensorType
+tt.rank = 1
+del tt.dimensions[:]
+tt.dimensions.add().constant.size = 1
+
+# Drop the expand_dims op and move the axes const before the reduce_mean
+# (MIL requires topological op order).
+new_ops = []
+for i, op in enumerate(ops):
+    if i == expand_idx or i == axes_const_idx:
+        continue
+    if i == reduce_idx:
+        new_ops.append(MIL_pb2.Operation())
+        new_ops[-1].CopyFrom(axes_const)
+    new_ops.append(MIL_pb2.Operation())
+    new_ops[-1].CopyFrom(op)
+del ops[:]
+ops.extend(new_ops)
+
+model = ct.models.MLModel(
+    spec,
+    weights_dir=src + "/Data/com.apple.CoreML/weights",
+    skip_model_load=True,
+)
+model.save(dst)
+print(f"patched: {dst}")


### PR DESCRIPTION
## Summary

Fixes FluidInference/FluidAudio#836 — KokoroAne synthesis fails at the vocoder on macOS 14 under **every** compute-unit preset, while the package declares a macOS 14 floor.

**Root cause**: the vocoder's second output `anchor` (a trace-keeping sentinel, discarded by every host) traced as `mean()` → rank-0 scalar → `unsqueeze(0)`. macOS 14's Espresso runtime mangles the rank-0 intermediate into rank 2 while reshaping the network:

- ANE presets: E5RT `"Output rank has changed after reshaping espresso network for blob = anchor_classic_cpu"`
- CPU/GPU presets: `"feature 'anchor' must be of rank 1, instead got a multi-array value of rank 2"`

macOS 15+ runtimes handle the chain correctly, which is why nothing in CI (all `macos-15`) caught it.

## Changes

- `convert-coreml.py` (en + zh pipelines): `anchor = x_pre.mean(dim=(1, 2))` — lowers to a single `reduce_mean(axes=[1, 2])` producing `[1]` directly, no rank-0 intermediate. Declared output shape unchanged.
- `patch-anchor-rank.py` (new): surgical MIL patch that retrofits already-published mlpackages without re-running conversion + palettization.

## Hosted artifacts

Already patched and uploaded to `FluidInference/kokoro-82m-coreml` ([`cdaea5e2`](https://huggingface.co/FluidInference/kokoro-82m-coreml/commit/cdaea5e293bf8aba9c60b6891088e4efc20b8fc3)): `ANE/`, `ANE-zh/`, `ANE-ja/` (ja vocoder is byte-identical to en). Weight blobs deduped — only MIL/metadata deltas changed.

## Validation

- `x_pre` bit-exact original vs patched (en + zh, CPU_ONLY)
- Patched models load + predict under ALL / CPU_AND_NE / CPU_AND_GPU (macOS 26, M-series)
- End-to-end `fluidaudiocli tts` with the patched compiled vocoder produces normal audio
- Not yet verified on an actual macOS 14 host (none available locally) — cheapest proof is rerunning the reporter's fluidaudio-rs `macos-14` workflow against the updated HF artifacts. Fallback if old Espresso still trips on the 3D→1D reduce: `keep_dims=True` rank-3 anchor (no rank-changing op at all) + matching output-description change.