### PR TITLE
docs(webgpu): browser-port knowledge for all fluidaudio-web models

### DIFF
--- a/knowledge/AGENTS.md
+++ b/knowledge/AGENTS.md
@@ -25,6 +25,9 @@ knowledge/
 │   ├── coremltools/                # Apple coremltools 9.0b1 docs
 │   └── neural-engine/              # Apple Neural Engine reference
 │
+├── webgpu/                         # Browser (WebGPU/WASM) port knowledge
+│   └── index.md                    # fluidaudio-web port index + cross-model runtime findings
+│
 └── AGENTS.md                        # This file
 ```
 
@@ -47,6 +50,11 @@ Key topics:
 - CoVoST 2: Massive multilingual speech translation (21→En, En→15)
 - Token-Duration Transducer: Joint token & duration prediction
 - Canary & Parakeet: Production-ready multilingual ASR (25 languages)
+
+### **Browser (WebGPU/WASM) Ports**
+For running FluidAudio's models in-browser (fluidaudio-web) — port index,
+ORT-web boundaries, portable-WGSL performance ceiling, mel-frontend matrix:
+→ See **[`webgpu/index.md`](./webgpu/index.md)**
 
 ### **CoreML Optimization & Deployment**
 For on-device LLM and neural network deployment:

--- a/knowledge/webgpu/index.md
+++ b/knowledge/webgpu/index.md
@@ -23,9 +23,16 @@ across models. Extracted raw weights for every engine are hosted at
 | ACE-Step 1.5 Turbo (3.5B) | `musicgen-acestep` | ~1.9× RT, seed-deterministic | upstream port (Hamza Q.), vendored `packages/acestep` |
 
 One shared hand-written FastConformer forward serves Parakeet / Nemotron /
-EOU / Sortformer / VoiceChat — the config (d_model, layers, heads, d_ff, dw
-kernel, subsampling, mel bins) is **inferred from the weight manifest**, so a
-new FastConformer variant is a weight-extraction job, not a runtime job.
+EOU / Sortformer / VoiceChat. **Geometry** (d_model, layers, heads, d_ff, dw
+kernel, subsampling channels, mel bins) is inferred from the weight manifest,
+but the **non-weight semantics are NOT in the manifest** and must be recovered
+from the NeMo config per variant and passed as an engine config override
+(`VOICECHAT_CFG`, `NEMO_CFG`, …): causal vs symmetric subsampling pad, causal
+vs symmetric depthwise conv, conv-norm type (batch_norm vs layer_norm),
+attention chunking/context ([70,0] ⇒ chunk 1; Nemotron chunk 4 / left 56 /
+right 3), and the mel frontend (matrix below). A new variant is therefore a
+weight-extraction job **plus** a config-recovery job — the runtime code itself
+stays untouched.
 
 ## Cross-cutting runtime findings
 

--- a/knowledge/webgpu/index.md
+++ b/knowledge/webgpu/index.md
@@ -1,0 +1,79 @@
+# WebGPU/WASM ports — fluidaudio-web runtime knowledge
+
+Cross-model findings from porting FluidAudio's models to the browser in
+[fluidaudio-web](https://github.com/FluidInference/fluidaudio-web) as
+hand-written WebGPU/WASM forwards (no onnxruntime). Per-model port notes live
+next to each model's trial README (see table); this note holds what transfers
+across models. Extracted raw weights for every engine are hosted at
+[`FluidInference/fluidaudio-web`](https://huggingface.co/FluidInference/fluidaudio-web)
+(flat `.bin` + `manifest.json` of `name → {dims, offset, len}` in elements).
+
+## Port index
+
+| model | engine | in-browser result | per-model notes |
+|---|---|---|---|
+| Parakeet TDT v3 0.6B | `asr-parakeet` | WER 2.15% LibriSpeech (native parity), 282× RT | `models/stt/parakeet-tdt-v3-0.6b/coreml/README.md` |
+| Parakeet Realtime EOU 120M | `eou-parakeet` | 297× RT, streaming == offline bit-exact | `models/stt/parakeet-realtime-eou-120m/coreml/README.md` |
+| Nemotron 3.5 multilingual 0.6B | `asr-nemotron` | matches ORT streaming reference | `models/stt/nemotron-asr-streaming-multilingual-0.6b/coreml/README.md` |
+| VoiceChat-11B STT (609M enc) | `asr-voicechat` | byte-identical to torch/CoreML oracle, 34.6× RT | `models/s2s/nemotron-voicechat-11b/README.md` |
+| Whisper base | `asr-whisper` | matches transformers.js transcript | below (no mobius trial dir) |
+| Sortformer 4-spk v2.1 | `diarization-sortformer` | fp32 parity 1.79e-7 | `models/speaker-diarization/sortformer-streaming/README.md` |
+| Kokoro 82M en/zh | `tts-kokoro` | waveform corr ~0.97, ~10× RT | `models/tts/kokoro/coreml/README.md`, `models/tts/kokoro-v1.1-zh/coreml/README.md` |
+| Silero VAD v5 | `vad-silero` | prob parity ~1e-6, weights bundled (1.2 MB) | `models/vad/silero-vad/coreml/README.md` |
+| ACE-Step 1.5 Turbo (3.5B) | `musicgen-acestep` | ~1.9× RT, seed-deterministic | upstream port (Hamza Q.), vendored `packages/acestep` |
+
+One shared hand-written FastConformer forward serves Parakeet / Nemotron /
+EOU / Sortformer / VoiceChat — the config (d_model, layers, heads, d_ff, dw
+kernel, subsampling, mel bins) is **inferred from the weight manifest**, so a
+new FastConformer variant is a weight-extraction job, not a runtime job.
+
+## Cross-cutting runtime findings
+
+**ORT-web boundaries (why the raw runtime exists):**
+- ORT's WebGPU EP has **no int8/int4 kernels**. Int-quantized encoders either
+  silently fall back to WASM or (int4 MatMulNBits) run a buggy WebGPU kernel
+  that returns garbage without falling back.
+- Chrome caps ArrayBuffers at ~2 GB — multi-GB fp32 external-data ONNX files
+  cannot load at all; self-contained fp16 exports are the fix.
+- Single-threaded WASM (no cross-origin isolation on GitHub Pages) blocks the
+  main thread for seconds on ~700 MB encoders — workerize, or go WebGPU.
+
+**Quantization tolerance is a function of model size** (same RTN scheme):
+0.6B encoders are int8-robust; the 120M EOU degrades under int8 and needs
+fp16; the 9B VoiceChat LLM loses 25% top-1 to int4 RTN and is only lossless
+at int8. Check encoder output std (healthy O(1) vs collapsed ~0.02) before
+blaming anything downstream.
+
+**Mel frontend matrix — mixups present exactly like decode bugs** (flat,
+content-free encoder output → all-blank RNNT):
+| model | normalization | log guard |
+|---|---|---|
+| Parakeet v3 / Sortformer | per-feature CMVN | 2^-24 |
+| Nemotron / EOU | NA (none) | 1e-10 |
+| VoiceChat | NA (none) | 2^-24 |
+
+**Portable-WGSL performance ceiling (measured, M5 Pro, closed investigation):**
+- Register-blocked GEMM plateaus at ~2.2 TFLOP/s ≈ 16% of fp32 peak; the rest
+  needs simdgroup/cooperative-matrix units, which portable WGSL does not
+  expose. This is also why hand-rolled WGSL only *ties* ORT-WebGPU on speed.
+- f16 storage gives 1.5–2× only on large **square** GEMMs (≥2048³). Real
+  speech-model GEMMs are thin (K=N≈1024, small M) and occupancy-bound —
+  f16 measured 0× end-to-end on Kokoro AND Parakeet.
+- **Denormals cost ~2×** on Metal-backed WebGPU: uninitialized GPU buffers
+  full of garbage denormals doubled a full-forward replay (389→202 ms).
+  Zero-init buffers; time submit→onSubmittedWorkDone, not the record loop.
+- The one genuine raw-WGSL capability over ORT-web: **in-shader int4/int8
+  dequant matmul** (ONNX MatMulNBits layout: packed nibbles [N, nblk, 16] +
+  per-block scales/zero-points) — runs models ORT-WebGPU cannot run at all.
+- Metal `tanh(x)` = exp/exp → NaN for large |x| (CPU saturates); clamp the
+  gelu/tanh argument (±20). Large-K accumulators surface it; small tests hide it.
+
+## Whisper base (no mobius trial dir)
+
+Hand-written raw port (`asr-whisper`): WhisperMel 80-bin log-mel via direct
+400-pt DFT in JS (1.4e-5 vs transformers.js), conv stem + 6 PRE-LN
+transformer layers with **erf-GELU** (not tanh-approx), autoregressive greedy
+decoder (causal self-attn + cross-attn) with the forced prefix
+`<|startoftranscript|> <|en|> <|transcribe|> <|notimestamps|>`, suppress-token
+list, and a GPT-2 byte-level BPE detokenizer. Single 30 s window; long-audio
+chunking is a follow-up. Weights: `whisper/` (fp32 encoder + decoder).

--- a/models/speaker-diarization/sortformer-streaming/README.md
+++ b/models/speaker-diarization/sortformer-streaming/README.md
@@ -132,3 +132,28 @@ https://github.com/FluidInference/FluidAudio/blob/main/Documentation/Benchmarks.
 
   This project was built upon the foundational work of the NVIDIA NeMo team.
 
+
+## WebGPU/WASM port knowledge (browser)
+
+Sortformer 4-spk v2.1 runs fully in-browser in
+[fluidaudio-web](https://github.com/FluidInference/fluidaudio-web)
+(`src/engines/diarization-sortformer/`) — ORT-free: the shared WGSL
+FastConformer encoder (int8, 17 layers, d512, symmetric Parakeet-style
+subsampling, full attention offline) → Sortformer head (encoder_proj →
+18-layer transformer → single_hidden_to_spks → sigmoid) → per-frame
+4-speaker probs (~12.5 fps) → threshold/merge into segments. mel =
+per-feature CMVN. Parity vs ORT: fp32 maxΔ 1.79e-7, int8 2.3e-3. Weights:
+`FluidInference/fluidaudio-web` → `sortformer/`.
+
+Load-bearing facts:
+
+- **Offline single-chunk (EMPTY spkcache/fifo) only works for short audio.**
+  On long meetings it collapses to the dominant speaker (secondary speakers
+  → 0.000) — the spkcache/fifo streaming state loop is NOT optional there.
+  Valid long-form DER requires porting NeMo's streaming state update.
+- **NeMo's own ONNX export of this model has dynamic-slice issues**;
+  community mirrors (`cgus/diar_streaming_sortformer_4spk-v2.1-onnx`) work.
+- **NeMo xscaling (√512) is a runtime Mul in this export**, not folded into
+  weights — easy to drop when porting from the graph.
+- The fp32 model is CPU-runnable (not precision-gated like the int-quant ASR
+  encoders) → fully verifiable headless before touching a browser.

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/coreml/README.md
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/coreml/README.md
@@ -302,3 +302,41 @@ hint, not as a hard LID.
 ## License & Distribution
 
 The source model is under the **NVIDIA Software and Model Evaluation License** and is currently marked "internal NVIDIA evaluation". Per the upstream README, contact `jaydar@nvidia.com` for access. Do **not** upload converted artifacts publicly without confirming redistribution terms. Local on-device use within VoiceLink is fine per project policy (`/Users/kikow/.claude/CLAUDE.md`, project `CLAUDE.md`).
+
+## WebGPU/WASM port knowledge (browser)
+
+Nemotron 3.5 multilingual runs fully in-browser in
+[fluidaudio-web](https://github.com/FluidInference/fluidaudio-web)
+(`src/engines/asr-nemotron/`) — ORT-free, on the shared WGSL FastConformer
+runtime with the Nemotron streaming config (causal subsampling pad, causal
+depthwise dwK 9, cache-aware attention mask chunk 4 / left 56 / right 3).
+The cache-aware streaming export and offline-with-limited-context-mask compute
+the same function, so the browser runs the model offline and skips the cache
+plumbing entirely. Weights: `FluidInference/fluidaudio-web` → `nemotron/`
+(int8 encoder 630 MB + fp32 decoder 98 MB — the 600M encoder is int8-robust,
+unlike the 120M EOU).
+
+Load-bearing facts:
+
+- **THE lang_id gotcha**: language ids are ordinals of the 40 `<xx-XX>` vocab
+  tokens (`languages.json` promptDictionary; en-US = 24). Defaulting lang_id
+  to 0 selects *Bulgarian*, and the joint then predicts blank on every frame —
+  an EMPTY transcript that was originally misdiagnosed as int4 quantization
+  degeneracy. Before blaming quant, check encoder output std and
+  task-conditioning inputs.
+- **prompt_kernel** (multilingual conditioning): concat conformer_out[1024]
+  with the language one-hot[128] → MLP 1152→2048→1024 → encoded_output.
+  Since one-hot(lang) @ W just selects row 1024+langId, the language half
+  folds into the first layer's bias — no concat needed at runtime.
+- **Mel is NA (no CMVN) with log guard 1e-10** — Nemotron's own choice, vs
+  2^-24 NeMo default used by Parakeet (with CMVN) and VoiceChat (NA). Input
+  is T-major.
+- **RNNT decode**: 2-layer LSTM prednet, joint → 13088 logits, blank 13087;
+  the export does NOT prepend a zero-SOS timestep (single LSTM step per call
+  — unlike the EOU fused export); argmax is invariant to LogSoftmax, so skip
+  it in greedy decode.
+- **ORT-web history that motivated the raw port**: the int4 ONNX encoder is
+  healthy on WASM (output std 0.43) but ORT's WebGPU EP runs its buggy int4
+  MatMulNBits kernel instead of falling back → empty output; and
+  single-threaded WASM (GitHub Pages, no cross-origin isolation) froze the
+  main thread on the 690 MB encoder until the engine was workerized.

--- a/models/stt/nemotron-asr-streaming-multilingual-0.6b/coreml/README.md
+++ b/models/stt/nemotron-asr-streaming-multilingual-0.6b/coreml/README.md
@@ -311,8 +311,11 @@ Nemotron 3.5 multilingual runs fully in-browser in
 runtime with the Nemotron streaming config (causal subsampling pad, causal
 depthwise dwK 9, cache-aware attention mask chunk 4 / left 56 / right 3).
 The cache-aware streaming export and offline-with-limited-context-mask compute
-the same function, so the browser runs the model offline and skips the cache
-plumbing entirely. Weights: `FluidInference/fluidaudio-web` → `nemotron/`
+the same function — that equivalence is what made the port tractable and is how
+whole-clip (batch) transcription runs. The shipped engine is additionally TRUE
+streaming: push()/finish() over a streaming mel + cache-carrying encode stream,
+with a 4-chunk provisional-tail lookahead to honor the export's right-context 3
+(fluidaudio-web docs/STREAMING.md). Weights: `FluidInference/fluidaudio-web` → `nemotron/`
 (int8 encoder 630 MB + fp32 decoder 98 MB — the 600M encoder is int8-robust,
 unlike the 120M EOU).
 

--- a/models/stt/parakeet-realtime-eou-120m/coreml/README.md
+++ b/models/stt/parakeet-realtime-eou-120m/coreml/README.md
@@ -114,3 +114,37 @@ for chunk in chunks[1:]:
 - [Model Card](https://huggingface.co/alexwengg/parakeet-realtime-eou-120m-coreml/tree/main)
 - [FastConformer Paper](https://arxiv.org/abs/2305.05084)
 - [Cache-Aware Streaming](https://arxiv.org/abs/2312.17279)
+
+## WebGPU/WASM port knowledge (browser)
+
+The EOU model also runs fully in-browser in
+[fluidaudio-web](https://github.com/FluidInference/fluidaudio-web)
+(`src/engines/eou-parakeet/`) — ORT-free, on the same shared WGSL
+FastConformer runtime as Parakeet/Nemotron/VoiceChat, with the streaming
+config (causal subsampling pad, causal depthwise conv, conv-module LayerNorm,
+cache-aware chunked attention mask: chunk 2, left context 70). **297×
+real-time** on a 1-hour file (worker-overlapped wasm decode + linear-cost
+streaming encode); TRUE streaming push()/finish() is bit-exact with the
+offline path (cache-carrying encode). Weights:
+`FluidInference/fluidaudio-web` → `eou/` (fp16 encoder 219 MB + fp32 decoder
+21 MB).
+
+Load-bearing facts for anyone porting this model to another runtime:
+
+- **THE gotcha — this model wants NA (un-normalized) log-mel, not Parakeet's
+  per-feature CMVN.** Feeding CMVN mel makes the encoder emit content-free
+  frames (per-frame RMS looks normal but std is nearly flat ~0.04 across the
+  whole clip) → the joint predicts blank on every step → empty transcript
+  that presents exactly like a decode bug. Diagnostic that cracked it: mel
+  bit-identical to reference, decode logic verified against reference, yet
+  all-blank ⇒ the encoder *input contract* is wrong.
+- **fp16 encoder is required — int8 degrades this 120M model** (unlike the
+  0.6B, which tolerates int8). Small models are much more quant-sensitive.
+- **RNNT export shape quirks** (ysdede `parakeet-realtime-eou-120m-v1-onnx`,
+  fused decoder_joint): single-layer LSTM states [1,1,640], NO target_length
+  input; the joint output grid carries size-1 time/label dims — take the LAST
+  1027 values; the exported joint prepends a zero-SOS timestep, so the LSTM
+  steps twice per call.
+- **Control tokens**: eou_id 1024, eob_id 1025, blank 1026 (vocab 1024 text
+  pieces). Ids ≥ 1024 become timestamped events and are dropped from the
+  transcript.

--- a/models/stt/parakeet-tdt-v3-0.6b/coreml/README.md
+++ b/models/stt/parakeet-tdt-v3-0.6b/coreml/README.md
@@ -193,3 +193,38 @@ Examples
 
 - Parakeet‑TDT v3 model from NVIDIA NeMo (`nvidia/parakeet-tdt-0.6b-v3`).
 - This directory provides export/validation utilities and plots to help the community reproduce quality and performance on Apple devices.
+
+## WebGPU/WASM port knowledge (browser)
+
+Parakeet v3 also runs fully in-browser in
+[fluidaudio-web](https://github.com/FluidInference/fluidaudio-web)
+(`src/engines/asr-parakeet/`) — ORT-free: a hand-written WGSL FastConformer
+forward whose config (d_model, layers, heads, d_ff, dw kernel, subsampling
+channels, mel bins) is inferred from the weight manifest, so the same runtime
+serves Parakeet / Nemotron / EOU / Sortformer / VoiceChat. Encoder parity vs
+ORT 5.3e-7; full LibriSpeech test-clean WER **2.15%** = parity with the native
+pipeline; **282× real-time** on a 1-hour file in-browser (GPU encode +
+wasm-SIMD RNNT decode). Weights: `FluidInference/fluidaudio-web` → `parakeet/`
+(int8 encoder 612 MB + fp32 decoder/joint 72 MB; int8 is a download/storage
+format with per-tensor scales, dequantized to fp32 at load — ~2.3 GB → 1.17 GB
+resident).
+
+Load-bearing facts for anyone porting this model to a browser runtime:
+
+- **ORT-web's WebGPU EP has NO int8/int4 kernels.** Int-quantized encoders
+  silently fall back to WASM (or worse, see next) — this is what motivated the
+  raw-WGSL runtime.
+- **The int8 ONNX encoder is degenerate on CPU/WASM execution**: output
+  collapses to ~0 (std 0.017 vs O(1) healthy) → all-blank, empty transcript.
+  It is healthy under fp16 GPU compute. Check encoder output std before
+  blaming the decoder.
+- **Chrome caps ArrayBuffers at ~2 GB**: the fp32 encoder's 2.44 GB external
+  .data cannot load in-browser at all. The self-contained fp16 export
+  (1.24 GB) fits and preserves WER exactly.
+- **Mel frontend is per-feature CMVN with log guard 2^-24** — NOT the NA
+  (un-normalized) frontend of Nemotron (1e-10) or VoiceChat/EOU (NA). Mixing
+  up FastConformer mel frontends produces content-free encoder output that
+  looks exactly like a decode bug.
+- **TDT greedy specifics**: joint emits 8198 = 8193 vocab (blank 8192) + 5
+  duration bins; advance time by the argmax duration; update the prednet LSTM
+  state only on non-blank; cap symbols per step at 10.

--- a/models/tts/kokoro-v1.1-zh/coreml/README.md
+++ b/models/tts/kokoro-v1.1-zh/coreml/README.md
@@ -181,3 +181,22 @@ cp build/kokoro-v1.1-zh/{zf_001.bin,zm_009.bin} build/kokoro-v1.1-zh-hf/
 MIT — see `LICENSE`. Original conversion © laishere; v1.0 mobius adaptation +
 v1.1-zh switch © FluidInference. Underlying Kokoro-82M-v1.1-zh model
 © hexgrad (Apache-2.0).
+
+## WebGPU/WASM port knowledge (browser)
+
+The browser Chinese voice in
+[fluidaudio-web](https://github.com/FluidInference/fluidaudio-web) uses this
+v1.1 zh model on the same hand-written WGSL synth as English (see
+`models/tts/kokoro/coreml/README.md`), with a JS-only frontend
+(`src/engines/tts-kokoro/zh-frontend-v11.js`):
+
+- **kokoro-js's zh path is broken by construction** — it routes hanzi through
+  espeak with English voices. The fix is phoneme injection: build phonemes
+  yourself and feed them directly, skipping espeak entirely.
+- **Frontend chain**: pinyin-pro (hanzi → pinyin, context polyphones,
+  segmentation, non-zh passthrough) → misaki[zh] **v1.1 format** (Bopomofo +
+  tone digits). misaki[zh] has no JS port — the mapping was precomputed from
+  the misaki oracle and verified byte-exact against it.
+- Native zf_/zm_ voice packs and g2pW-grade polyphone disambiguation remain
+  the quality gaps vs the Python stack (pinyin-pro's dict is the current
+  polyphone source).

--- a/models/tts/kokoro/coreml/README.md
+++ b/models/tts/kokoro/coreml/README.md
@@ -366,3 +366,35 @@ See component licenses for details.
 ---
 
 **Version**: v21 (FP32) | **Updated**: 2024-10-06 | **Requires**: iOS 17+, macOS 14+
+
+## WebGPU/WASM port knowledge (browser)
+
+Kokoro 82M runs fully in-browser in
+[fluidaudio-web](https://github.com/FluidInference/fluidaudio-web)
+(`src/engines/tts-kokoro/`, synth core `src/gpu/kokoro-synth.js`) — ORT-free,
+no kokoro-js/transformers.js: the whole StyleTTS2 + iSTFTNet pipeline (ALBERT
+frontend → prosody predictor → SineGen → decoder/generator) hand-ported to raw
+WebGPU/WASM. Parity vs the ONNX model: waveform corr ~0.97, source spectrum
+exact, decoder body 5e-5; ALBERT frontend 4.2e-6. Weights:
+`FluidInference/fluidaudio-web` → `kokoro/` and `kokoro-zh/` (flat fp32 blob +
+manifest + roles map).
+
+Load-bearing facts for porting Kokoro to any hand-written runtime:
+
+- **ALBERT nn.Linear weights are ANONYMOUS initializers** (`onnx::MatMul_*`)
+  — trace each via the *named bias* it feeds (the Add consuming
+  `...query.bias` → its MatMul → the weight); orientation arrives [in, out].
+- **ONNX LSTM gate order is iofc** (PyTorch is ifgo) — reorder at extraction.
+  All 6 Kokoro LSTMs are bidirectional hidden-256, so one kernel covers them.
+- **No FFT kernel is needed**: the exported iSTFT is a Cos/Sin DFT matmul +
+  ConvTranspose overlap-add; SineGen and the STFT recombine are cheap
+  host-side one-shots.
+- **The vocoder is the model**: iSTFTNet decoder ≈ 90% of compute (Conv alone
+  64%); the ALBERT text encoder is only ~5%. Optimize convs or nothing.
+- **Raw WGSL ties kokoro-js (~10× RT), it does not beat it** — the convs are
+  memory/occupancy-bound at thin shapes; see `knowledge/webgpu/` for the
+  portable-WGSL ceiling measurements that closed that investigation.
+- **G2P without espeak**: English is lexicon-first (FluidAudio's
+  `us_lexicon_cache.json`, Kokoro-vocab-exact IPA token arrays, hosted at the
+  kokoro HF repo root); out-of-lexicon words are skipped — there is no espeak
+  fallback in the browser build.

--- a/models/vad/silero-vad/coreml/README.md
+++ b/models/vad/silero-vad/coreml/README.md
@@ -100,3 +100,22 @@ uv run python compare-models.py --audio-file ../FluidAudio/yc.wav  --include-256
   email = {hello@fluidinference.com}
 }
 ```
+
+## WebGPU/WASM port knowledge (browser)
+
+Silero VAD v5 runs in
+[fluidaudio-web](https://github.com/FluidInference/fluidaudio-web)
+(`src/engines/vad-silero/`) as a hand-written JS forward of the 16 kHz path —
+no onnxruntime, and the ~1.2 MB extracted weights are bundled with the app
+(zero model download). Parity vs ORT: ~1e-6 on per-window speech probability
+across a full streaming sequence.
+
+- **v5 I/O contract**: `input[1,512]` + `state[2,1,128]` + `sr` (int64
+  **scalar**) → `prob[1,1]` + next state; one probability per 512-sample
+  (32 ms) hop.
+- Segmenter: hysteresis thresholds (0.5 enter / −0.15 exit) + min-speech
+  250 ms / min-silence 100 ms / 30 ms pad merge.
+- Motivation for the raw port: @ricky0123/vad-web's CJS
+  `require("onnxruntime-web/wasm")` is unresolvable under Vite once ORT
+  leaves optimizeDeps — the dependency fought the bundler harder than the
+  2 MB model fought the port.


### PR DESCRIPTION
## Summary

Every FluidAudio model that runs in-browser in [fluidaudio-web](https://github.com/FluidInference/fluidaudio-web) now has its load-bearing port knowledge recorded in mobius, next to the corresponding CoreML trial — mirroring the VoiceChat treatment in #85. All engines are ORT-free hand-written WebGPU/WASM forwards; one shared FastConformer runtime (config inferred from the weight manifest) serves Parakeet / Nemotron / EOU / Sortformer / VoiceChat. Weights for all engines are hosted at [`FluidInference/fluidaudio-web`](https://huggingface.co/FluidInference/fluidaudio-web).

## Per-model sections added

| trial README | headline facts |
|---|---|
| `parakeet-tdt-v3-0.6b` | WER 2.15% = native parity, 282× RT; int8 ONNX encoder degenerate on CPU but healthy on GPU; Chrome ~2 GB ArrayBuffer cap vs fp32 external data; per-feature CMVN mel; TDT greedy = 8193 vocab + 5 duration bins |
| `parakeet-realtime-eou-120m` | 297× RT; wants NA mel — CMVN mel ⇒ all-blank that presents as a decode bug; **int8 degrades the 120M** (0.6B tolerates it); fused-joint quirks (last-1027 slice, zero-SOS prepend); ids eou 1024/eob 1025/blank 1026 |
| `nemotron-asr-streaming-multilingual-0.6b` | **lang_id ordinals from the 40 `<xx-XX>` vocab tokens — default 0 = Bulgarian ⇒ empty transcript misdiagnosed as int4 degeneracy**; prompt_kernel one-hot folds into a bias; NA mel + 1e-10 guard; no zero-SOS; ORT-web int4 WebGPU kernel returns garbage without falling back |
| `sortformer-streaming` | empty-state single-chunk collapses to the dominant speaker on long audio (streaming spkcache/fifo loop is not optional); NeMo's own ONNX export has dynamic-slice issues, community mirrors work; xscaling √512 is a runtime Mul |
| `kokoro` + `kokoro-v1.1-zh` | anonymous ALBERT initializers traced via named biases; iofc vs ifgo gate order; exported iSTFT = DFT-matmul + ConvTranspose (no FFT kernel needed); vocoder = 90% of compute; zh = phoneme injection (pinyin-pro → misaki v1.1 format), espeak zh path broken by construction |
| `silero-vad` | v5 I/O contract (`sr` is an int64 **scalar**), hysteresis segmenter params, 1.2 MB bundled weights = zero download |

## New: `knowledge/webgpu/index.md`

Cross-model index + the findings that transfer between ports: ORT-web has no int8/int4 kernels (and its int4 WebGPU kernel fails non-gracefully); quantization tolerance scales with model size (0.6B int8-ok → 120M needs fp16 → 9B int4-RTN unusable); the mel-frontend matrix (CMVN/NA × 2^-24/1e-10) whose mixups present exactly like decode bugs; the measured portable-WGSL ceiling (GEMM plateau ~16% of fp32 peak without simdgroup access, f16 storage only pays on ≥2048³ square GEMMs, denormals cost 2×, Metal tanh NaN); and in-shader int4 dequant as the one capability raw WGSL has over ORT-web. Whisper base's port facts live here (it has no mobius trial dir). Indexed from `knowledge/AGENTS.md`.

ACE-Step is the one engine intentionally not covered — it's the upstream author's port, vendored wholesale; its knowledge lives in fluidaudio-web's `packages/acestep`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)