### PR TITLE
Add grouped INT4 Parakeet Core ML export

### DIFF
--- a/models/stt/parakeet-tdt-v3-0.6b/coreml/.gitignore
+++ b/models/stt/parakeet-tdt-v3-0.6b/coreml/.gitignore
@@ -3,6 +3,7 @@ parakeet_coreml/
 parakeet_coreml_quantized/
 parakeet_coreml_encoder_only/
 parakeet_coreml_fp32/
+parakeet_coreml_fp16/
 compiled/
 .compiled/
 compute_unit_sweep.json

--- a/models/stt/parakeet-tdt-v3-0.6b/coreml/README.md
+++ b/models/stt/parakeet-tdt-v3-0.6b/coreml/README.md
@@ -97,17 +97,18 @@ Quantization plots (ALL)
 
 ## Encoder-only int4/int8 sweep
 
-`extra_encoder_variants.py` extends the recipes in `quantize_coreml.py` with five encoder-scoped variants targeting the disk/RTFx/WER trade space. The encoder dominates the v3 model footprint, so quantizing it alone (without touching preprocessor/decoder/joint, which stay fp16) gives most of the size win without further hurting decoding quality.
+`extra_encoder_variants.py` extends the recipes in `quantize_coreml.py` with six encoder-scoped variants targeting the disk/RTFx/WER trade space. The encoder dominates the v3 model footprint, so quantizing it alone (without touching preprocessor/decoder/joint, which stay fp16) gives most of the size win without further hurting decoding quality.
 
 Variants:
 
 - `enc8bit-palettize` — 8-bit palette on the encoder.
 - `enc-prune+int8` — sparse + int8 linear per-channel.
 - `enc-int4-linear-per-channel` — int4 linear, one scale per output channel. Selected as the FluidAudio v3 default.
+- `enc-int4-palettize-grouped-16` — int4 k-means palette over groups of 16 output channels.
 - `enc-int4-linear-per-block-32` — int4 linear, one scale per 32-element block.
 - `enc-prune+int4-block` — sparse + int4 block-wise.
 
-The three int4 variants explicitly bump `spec.specificationVersion = 9` (iOS18 / macOS 15) after the optimize.coreml pass, since int4 weight payloads require the iOS18 runtime.
+The four int4 variants explicitly bump `spec.specificationVersion = 9` (iOS18 / macOS 15) after the optimize.coreml pass, since int4 weight payloads require the iOS18 runtime.
 
 ```
 uv run python extra_encoder_variants.py run \

--- a/models/stt/parakeet-tdt-v3-0.6b/coreml/extra_encoder_variants.py
+++ b/models/stt/parakeet-tdt-v3-0.6b/coreml/extra_encoder_variants.py
@@ -7,6 +7,7 @@ were not part of the original sweep:
   * ``enc8bit-palettize``        - 8-bit kmeans palettize (quality reference vs 6-bit)
   * ``enc-prune+int8``           - 50% threshold prune followed by int8-per-channel
   * ``enc-int4-linear-per-channel``    - int4 symmetric, per-output-channel
+  * ``enc-int4-palettize-grouped-16``  - int4 kmeans palette, grouped-channel-16
   * ``enc-int4-linear-per-block-32``   - int4 symmetric, per-block (block_size=32)
   * ``enc-prune+int4-block``     - 50% prune then int4-per-block-32
 
@@ -141,6 +142,23 @@ def _default_variants() -> List[EncoderVariant]:
             )],
             bump_to_ios18=True,
             description="Encoder: int4 symmetric, per-channel (iOS18)",
+        ),
+        EncoderVariant(
+            name="enc-int4-palettize-grouped-16",
+            steps=[(
+                "palettize",
+                OptimizationConfig(
+                    global_config=OpPalettizerConfig(
+                        mode="kmeans",
+                        nbits=4,
+                        granularity="per_grouped_channel",
+                        group_size=16,
+                        weight_threshold=512,
+                    )
+                ),
+            )],
+            bump_to_ios18=True,
+            description="Encoder: int4 grouped-channel palette, group_size=16 (iOS18)",
         ),
         EncoderVariant(
             name="enc-int4-linear-per-block-32",


### PR DESCRIPTION
## What

- Add an encoder-only 4-bit grouped-channel k-means palette candidate with group size 16.
- Document it in the Parakeet Core ML encoder sweep.
- Ignore the reproducible FP16 source export directory.

## Why

This makes the quality-preserving INT4 candidate used in the Apple Silicon evaluation reproducible through Mobius instead of leaving the recipe in a local script.

## Grill

- Decisions:
  - Compress only the encoder because it dominates artifact size.
  - Require the iOS 18/macOS 15 Core ML specification for grouped INT4.
  - Keep the recipe experimental; benchmark evidence decides promotion.

## Tests

- `uv run python -m py_compile models/stt/parakeet-tdt-v3-0.6b/coreml/extra_encoder_variants.py`
- Exported, compiled, and transcribed `enc-int4-palettize-grouped-16` on Apple Silicon.

## Opt-outs

- Full corpus and resource validation lives in the companion ASR PR.
